### PR TITLE
Added hdr_stddev() to header file

### DIFF
--- a/src/hdr_histogram.h
+++ b/src/hdr_histogram.h
@@ -150,6 +150,7 @@ int64_t hdr_max(struct hdr_histogram* h);
 int64_t hdr_value_at_percentile(struct hdr_histogram* h, double percentile);
 
 double hdr_mean(struct hdr_histogram* h);
+double hdr_stddev(struct hdr_histogram* h);
 bool hdr_values_are_equivalent(struct hdr_histogram* h, int64_t a, int64_t b);
 int64_t hdr_lowest_equivalent_value(struct hdr_histogram* h, int64_t value);
 int64_t hdr_count_at_value(struct hdr_histogram* h, int64_t value);


### PR DESCRIPTION
This should be exposed, right? If not, please disregard. Thanks!

Signed-off-by: Michael Penick <michael.penick@datastax.com>