### PR TITLE
Use CLOCK_MONOTONIC for hdr_time()

### DIFF
--- a/src/hdr_time.h
+++ b/src/hdr_time.h
@@ -25,7 +25,7 @@ void hdr_gettime(struct timespec* ts)
 
 void hdr_gettime(struct timespec* t)
 {
-    clock_gettime(CLOCK_REALTIME, t);
+    clock_gettime(CLOCK_MONOTONIC, t);
 }
 
 #else


### PR DESCRIPTION
CLOCK_REALTIME can jump forwards and backwards so it's not useful for
measuring elapsed time. Switch to CLOCK_MONOTONIC instead which is
guaranteed to increase monotonically.

Signed-off-by: Pekka Enberg <penberg@iki.fi>