### PR TITLE
Fix function definitions in headers

### DIFF
--- a/src/hdr_interval_recorder.h
+++ b/src/hdr_interval_recorder.h
@@ -16,17 +16,17 @@ struct hdr_interval_recorder
     struct hdr_writer_reader_phaser phaser;
 } __attribute__((aligned (8)));
 
-int hdr_interval_recorder_init(struct hdr_interval_recorder* r)
+static inline int hdr_interval_recorder_init(struct hdr_interval_recorder* r)
 {
     return hdr_writer_reader_phaser_init(&r->phaser);
 }
 
-void hdr_interval_recorder_destroy(struct hdr_interval_recorder* r)
+static inline void hdr_interval_recorder_destroy(struct hdr_interval_recorder* r)
 {
     hdr_writer_reader_phaser_destory(&r->phaser);
 }
 
-void hdr_interval_recorder_update(
+static inline void hdr_interval_recorder_update(
     struct hdr_interval_recorder* r, 
     void(*update_action)(void*, void*), 
     void* arg)
@@ -40,7 +40,7 @@ void hdr_interval_recorder_update(
     hdr_phaser_writer_exit(&r->phaser, val);
 }
 
-void* hdr_interval_recorder_sample(struct hdr_interval_recorder* r)
+static inline void* hdr_interval_recorder_sample(struct hdr_interval_recorder* r)
 {
     void* temp;
 

--- a/src/hdr_time.h
+++ b/src/hdr_time.h
@@ -10,7 +10,7 @@
 #include <mach/clock.h>
 #include <mach/mach.h>
 
-void hdr_gettime(struct timespec* ts)
+static inline void hdr_gettime(struct timespec* ts)
 {
     clock_serv_t cclock;
     mach_timespec_t mts;
@@ -23,7 +23,7 @@ void hdr_gettime(struct timespec* ts)
 
 #elif __linux__
 
-void hdr_gettime(struct timespec* t)
+static inline void hdr_gettime(struct timespec* t)
 {
     clock_gettime(CLOCK_REALTIME, t);
 }

--- a/src/hdr_writer_reader_phaser.h
+++ b/src/hdr_writer_reader_phaser.h
@@ -22,22 +22,22 @@ struct hdr_writer_reader_phaser
     pthread_mutex_t* reader_mutex;
 } __attribute__((aligned (8)));
 
-int64_t _hdr_phaser_get_epoch(int64_t* field)
+static inline int64_t _hdr_phaser_get_epoch(int64_t* field)
 {
     return __atomic_load_n(field, __ATOMIC_SEQ_CST);
 }
 
-void _hdr_phaser_set_epoch(int64_t* field, int64_t val)
+static inline void _hdr_phaser_set_epoch(int64_t* field, int64_t val)
 {
     __atomic_store_n(field, val, __ATOMIC_SEQ_CST);
 }
 
-int64_t _hdr_phaser_reset_epoch(int64_t* field, int64_t initial_value)
+static inline int64_t _hdr_phaser_reset_epoch(int64_t* field, int64_t initial_value)
 {
     return __atomic_exchange_n(field, initial_value, __ATOMIC_SEQ_CST);
 }
 
-int hdr_writer_reader_phaser_init(struct hdr_writer_reader_phaser* p)
+static inline int hdr_writer_reader_phaser_init(struct hdr_writer_reader_phaser* p)
 {
     if (NULL == p)
     {
@@ -65,17 +65,17 @@ int hdr_writer_reader_phaser_init(struct hdr_writer_reader_phaser* p)
     return 0;
 }
 
-void hdr_writer_reader_phaser_destory(struct hdr_writer_reader_phaser* p)
+static inline void hdr_writer_reader_phaser_destory(struct hdr_writer_reader_phaser* p)
 {
     pthread_mutex_destroy(p->reader_mutex);
 }
 
-int64_t hdr_phaser_writer_enter(struct hdr_writer_reader_phaser* p)
+static inline int64_t hdr_phaser_writer_enter(struct hdr_writer_reader_phaser* p)
 {
     return __atomic_add_fetch(&p->start_epoch, 1, __ATOMIC_SEQ_CST);
 }
 
-void hdr_phaser_writer_exit(
+static inline void hdr_phaser_writer_exit(
     struct hdr_writer_reader_phaser* p, int64_t critical_value_at_enter)
 {
     int64_t* end_epoch = 
@@ -83,17 +83,17 @@ void hdr_phaser_writer_exit(
     __atomic_add_fetch(end_epoch, 1, __ATOMIC_SEQ_CST);
 }
 
-void hdr_phaser_reader_lock(struct hdr_writer_reader_phaser* p)
+static inline void hdr_phaser_reader_lock(struct hdr_writer_reader_phaser* p)
 {
     pthread_mutex_lock(p->reader_mutex);
 }
 
-void hdr_phaser_reader_unlock(struct hdr_writer_reader_phaser* p)
+static inline void hdr_phaser_reader_unlock(struct hdr_writer_reader_phaser* p)
 {
     pthread_mutex_unlock(p->reader_mutex);
 }
 
-void hdr_phaser_flip_phase(
+static inline void hdr_phaser_flip_phase(
     struct hdr_writer_reader_phaser* p, int64_t sleep_time_ns)
 {
     // TODO: is_held_by_current_thread


### PR DESCRIPTION
Functions defined in header files should be tagged with 'static inline'
to avoid linkage problems and GCC complaining about lack of prototypes
with strict warnings enabled.

Signed-off-by: Pekka Enberg <penberg@iki.fi>