### PR TITLE
Constify hdr_histogram parameters where possible.

### DIFF
--- a/src/hdr_histogram.h
+++ b/src/hdr_histogram.h
@@ -141,20 +141,20 @@ bool hdr_record_corrected_values(struct hdr_histogram* h, int64_t value, int64_t
  * @param from Histogram to copy values from.
  * @return The number of values dropped when copying.
  */
-int64_t hdr_add(struct hdr_histogram* h, struct hdr_histogram* from);
+int64_t hdr_add(struct hdr_histogram* h, const struct hdr_histogram* from);
 int64_t hdr_add_while_correcting_for_coordinated_omission(
         struct hdr_histogram* h, struct hdr_histogram* from, int64_t expected_interval);
 
-int64_t hdr_min(struct hdr_histogram* h);
-int64_t hdr_max(struct hdr_histogram* h);
-int64_t hdr_value_at_percentile(struct hdr_histogram* h, double percentile);
-double hdr_stddev(struct hdr_histogram* h);
-double hdr_mean(struct hdr_histogram* h);
-bool hdr_values_are_equivalent(struct hdr_histogram* h, int64_t a, int64_t b);
-int64_t hdr_lowest_equivalent_value(struct hdr_histogram* h, int64_t value);
-int64_t hdr_count_at_value(struct hdr_histogram* h, int64_t value);
-int64_t hdr_count_at_index(struct hdr_histogram* h, int32_t index);
-int64_t hdr_value_at_index(struct hdr_histogram* h, int32_t index);
+int64_t hdr_min(const struct hdr_histogram* h);
+int64_t hdr_max(const struct hdr_histogram* h);
+int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile);
+double hdr_stddev(const struct hdr_histogram* h);
+double hdr_mean(const struct hdr_histogram* h);
+bool hdr_values_are_equivalent(const struct hdr_histogram* h, int64_t a, int64_t b);
+int64_t hdr_lowest_equivalent_value(const struct hdr_histogram* h, int64_t value);
+int64_t hdr_count_at_value(const struct hdr_histogram* h, int64_t value);
+int64_t hdr_count_at_index(const struct hdr_histogram* h, int32_t index);
+int64_t hdr_value_at_index(const struct hdr_histogram* h, int32_t index);
 
 struct hdr_iter_percentiles
 {
@@ -194,7 +194,7 @@ struct hdr_iter_log
  */
 struct hdr_iter
 {
-    struct hdr_histogram* h;
+    const struct hdr_histogram* h;
     int32_t bucket_index;
     int32_t sub_bucket_index;
     int64_t count_at_index;
@@ -219,24 +219,24 @@ struct hdr_iter
  * @param itr 'This' pointer
  * @param h The histogram to iterate over
  */
-void hdr_iter_init(struct hdr_iter* iter, struct hdr_histogram* h);
+void hdr_iter_init(struct hdr_iter* iter, const struct hdr_histogram* h);
 
 /**
  * Initialise the iterator for use with percentiles.
  */
-void hdr_iter_percentile_init(struct hdr_iter* iter, struct hdr_histogram* h, int32_t ticks_per_half_distance);
+void hdr_iter_percentile_init(struct hdr_iter* iter, const struct hdr_histogram* h, int32_t ticks_per_half_distance);
 
 /**
  * Initialise the iterator for use with recorded values.
  */
-void hdr_iter_recorded_init(struct hdr_iter* iter, struct hdr_histogram* h);
+void hdr_iter_recorded_init(struct hdr_iter* iter, const struct hdr_histogram* h);
 
 /**
  * Initialise the iterator for use with linear values.
  */
 void hdr_iter_linear_init(
         struct hdr_iter* iter,
-        struct hdr_histogram* h,
+        const struct hdr_histogram* h,
         int64_t value_units_per_bucket);
 
 /**
@@ -244,7 +244,7 @@ void hdr_iter_linear_init(
  */
 void hdr_iter_log_init(
         struct hdr_iter* iter,
-        struct hdr_histogram* h,
+        const struct hdr_histogram* h,
         int64_t value_units_first_bucket,
         double log_base);
 
@@ -305,8 +305,8 @@ void hdr_init_preallocated(struct hdr_histogram* h, struct hdr_histogram_bucket_
 
 bool hdr_shift_values_left(struct hdr_histogram* h, int32_t binary_orders_of_magnitude);
 bool hdr_shift_values_right(struct hdr_histogram* h, int32_t shift);
-int64_t hdr_size_of_equivalent_value_range(struct hdr_histogram *h, int64_t value);
-int64_t hdr_next_non_equivalent_value(struct hdr_histogram *h, int64_t value);
-int64_t hdr_median_equivalent_value(struct hdr_histogram *h, int64_t value);
+int64_t hdr_size_of_equivalent_value_range(const struct hdr_histogram *h, int64_t value);
+int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t value);
+int64_t hdr_median_equivalent_value(const struct hdr_histogram *h, int64_t value);
 
 #endif


### PR DESCRIPTION
This is primarily to support the Rust binding I wrote (since Rust is much more particular about mutability than C), but it seems like its generally useful to know which functions cause changes and which are read-only.