### PR TITLE
Fixing compilation on Linux64bit - Clang 3.5.0

### DIFF
--- a/src/hdr_writer_reader_phaser.c
+++ b/src/hdr_writer_reader_phaser.c
@@ -4,6 +4,7 @@
  * as explained at http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdlib.h>


### PR DESCRIPTION
Adding missing include stdint.h in hdr_writer_reader_phaser.c