### PR TITLE
encoding: histogram encoding conflicts with b64 library

### DIFF
--- a/src/hdr_encoding.c
+++ b/src/hdr_encoding.c
@@ -197,17 +197,17 @@ static int from_base_64(int c)
     return EINVAL;
 }
 
-size_t base64_encoded_len(size_t decoded_size)
+size_t hdr_base64_encoded_len(size_t decoded_size)
 {
     return (size_t) (ceil(decoded_size / 3.0) * 4.0);
 }
 
-size_t base64_decoded_len(size_t encoded_size)
+size_t hdr_base64_decoded_len(size_t encoded_size)
 {
     return (encoded_size / 4) * 3;
 }
 
-void base64_encode_block_pad(const uint8_t* input, char* output, size_t pad)
+void hdr_base64_encode_block_pad(const uint8_t* input, char* output, size_t pad)
 {
     uint32_t _24_bit_value = 0;
 
@@ -242,7 +242,7 @@ void base64_encode_block_pad(const uint8_t* input, char* output, size_t pad)
 /**
  * Assumes that there is 3 input bytes and 4 output chars.
  */
-void base64_encode_block(const uint8_t* input, char* output)
+void hdr_base64_encode_block(const uint8_t* input, char* output)
 {
     uint32_t _24_bit_value = (input[0] << 16) + (input[1] << 8) + (input[2]);
 
@@ -252,10 +252,10 @@ void base64_encode_block(const uint8_t* input, char* output)
     output[3] = get_base_64(_24_bit_value,  0);
 }
 
-int base64_encode(
+int hdr_base64_encode(
     const uint8_t* input, size_t input_len, char* output, size_t output_len)
 {
-    if (base64_encoded_len(input_len) != output_len)
+    if (hdr_base64_encoded_len(input_len) != output_len)
     {
         return EINVAL;
     }
@@ -264,12 +264,12 @@ int base64_encode(
     int j = 0;
     for (; input_len - i >= 3 && j < output_len; i += 3, j += 4)
     {
-        base64_encode_block(&input[i], &output[j]);
+        hdr_base64_encode_block(&input[i], &output[j]);
     }
 
     size_t remaining = input_len - i;
 
-    base64_encode_block_pad(&input[i], &output[j], remaining);
+    hdr_base64_encode_block_pad(&input[i], &output[j], remaining);
 
     return 0;
 }
@@ -277,7 +277,7 @@ int base64_encode(
 /**
  * Assumes that there is 4 input chars available and 3 output chars.
  */
-void base64_decode_block(const char* input, uint8_t* output)
+void hdr_base64_decode_block(const char* input, uint8_t* output)
 {
     uint32_t _24_bit_value = 0;
 
@@ -291,7 +291,7 @@ void base64_decode_block(const char* input, uint8_t* output)
     output[2] = (uint8_t) ((_24_bit_value) & 0xFF);
 }
 
-int base64_decode(
+int hdr_base64_decode(
     const char* input, size_t input_len, uint8_t* output, size_t output_len)
 {
     if (input_len < 4 ||
@@ -303,7 +303,7 @@ int base64_decode(
 
     for (int i = 0, j = 0; i < input_len; i += 4, j += 3)
     {
-        base64_decode_block(&input[i], &output[j]);
+        hdr_base64_decode_block(&input[i], &output[j]);
     }
 
     return 0;

--- a/src/hdr_encoding.h
+++ b/src/hdr_encoding.h
@@ -33,7 +33,7 @@ int zig_zag_decode_i64(const uint8_t* buffer, int64_t* signed_value);
  * @param decoded_size the size of the unencoded values.
  * @return the encoded size
  */
-size_t base64_encoded_len(size_t decoded_size);
+size_t hdr_base64_encoded_len(size_t decoded_size);
 
 /**
  * Encode into base64.
@@ -43,7 +43,7 @@ size_t base64_encoded_len(size_t decoded_size);
  * @param output the buffer to write the output to
  * @param output_len the number of bytes to write to the output
  */
-int base64_encode(
+int hdr_base64_encode(
     const uint8_t* input, size_t input_len, char* output, size_t output_len);
 
 /**
@@ -53,7 +53,7 @@ int base64_encode(
  * @param encoded_size the size of the encoded value.
  * @return the decoded size
  */
-size_t base64_decoded_len(size_t encoded_size);
+size_t hdr_base64_decoded_len(size_t encoded_size);
 
 /**
  * Decode from base64.
@@ -63,7 +63,7 @@ size_t base64_decoded_len(size_t encoded_size);
  * @param output the buffer to write the decoded data to
  * @param output_len the number of bytes to write to the output data
  */
-int base64_decode(
+int hdr_base64_decode(
     const char* input, size_t input_len, uint8_t* output, size_t output_len);
 
 

--- a/src/hdr_histogram_log.c
+++ b/src/hdr_histogram_log.c
@@ -827,10 +827,10 @@ int hdr_log_write(
         FAIL_AND_CLEANUP(cleanup, result, rc);
     }
 
-    encoded_len = base64_encoded_len(compressed_len);
+    encoded_len = hdr_base64_encoded_len(compressed_len);
     encoded_histogram = calloc(encoded_len + 1, sizeof(char));
 
-    rc = base64_encode(
+    rc = hdr_base64_encode(
         compressed_histogram, compressed_len, encoded_histogram, encoded_len);
     if (rc != 0)
     {
@@ -1022,9 +1022,9 @@ int hdr_log_read(
     }
 
     size_t base64_len = strlen(base64_histogram);
-    size_t compressed_len = base64_decoded_len(base64_len);
+    size_t compressed_len = hdr_base64_decoded_len(base64_len);
 
-    r = base64_decode(
+    r = hdr_base64_decode(
         base64_histogram, base64_len, compressed_histogram, compressed_len);
 
     if (r != 0)
@@ -1064,10 +1064,10 @@ int hdr_log_encode(struct hdr_histogram* histogram, char** encoded_histogram)
         FAIL_AND_CLEANUP(cleanup, result, rc);
     }
 
-    encoded_len = base64_encoded_len(compressed_len);
+    encoded_len = hdr_base64_encoded_len(compressed_len);
     encoded_histogram_tmp = calloc(encoded_len + 1, sizeof(char));
 
-    rc = base64_encode(
+    rc = hdr_base64_encode(
         compressed_histogram, compressed_len, encoded_histogram_tmp, encoded_len);
     if (rc != 0)
     {
@@ -1088,11 +1088,11 @@ int hdr_log_decode(struct hdr_histogram** histogram, char* base64_histogram, siz
     uint8_t* compressed_histogram = NULL;
     int result = 0;
 
-    size_t compressed_len = base64_decoded_len(base64_len);
+    size_t compressed_len = hdr_base64_decoded_len(base64_len);
     compressed_histogram = malloc(sizeof(uint8_t)*compressed_len);
     memset(compressed_histogram, 0, compressed_len);
 
-    r = base64_decode(
+    r = hdr_base64_decode(
         base64_histogram, base64_len, compressed_histogram, compressed_len);
 
     if (r != 0)


### PR DESCRIPTION
So, in cases where b64 is linked in - the symbols will
conflict with this hdr histogram library.

Prefix the base64 code with hdr_ to just avoid the conflict
on static links.