### PR TITLE
Allow STD C89 build and be more strict about warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project("hdr_histogram")
 ENABLE_TESTING()
 
 if(UNIX)
-    set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self")
+    set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self -Wmissing-prototypes")
     set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     set(CMAKE_C_FLAGS_RELEASE "-O3 -g")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project("hdr_histogram")
 ENABLE_TESTING()
 
 if(UNIX)
-    set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self -Wmissing-prototypes")
+    set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self -Wmissing-prototypes -D_GNU_SOURCE")
     set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     set(CMAKE_C_FLAGS_RELEASE "-O3 -g")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project("hdr_histogram")
 ENABLE_TESTING()
 
 if(UNIX)
-    set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -std=gnu99")
+    set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self")
     set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     set(CMAKE_C_FLAGS_RELEASE "-O3 -g")
 endif()

--- a/examples/hiccup.c
+++ b/examples/hiccup.c
@@ -23,7 +23,7 @@
 #include <hdr_interval_recorder.h>
 #include <hdr_time.h>
 
-int64_t diff(struct timespec t0, struct timespec t1)
+static int64_t diff(struct timespec t0, struct timespec t1)
 {
     int64_t delta_us = 0;
     delta_us = (t1.tv_sec - t0.tv_sec) * 1000000;
@@ -32,7 +32,7 @@ int64_t diff(struct timespec t0, struct timespec t1)
     return delta_us;
 }
 
-void update_histogram(void* data, void* arg)
+static void update_histogram(void* data, void* arg)
 {
     struct hdr_histogram* h = data;
     int64_t* values = arg;
@@ -40,7 +40,7 @@ void update_histogram(void* data, void* arg)
     hdr_record_value(h, values[0]);
 }
 
-void* record_hiccups(void* thread_context)
+static void* record_hiccups(void* thread_context)
 {
     struct pollfd fd;
     struct timespec t0;
@@ -90,7 +90,7 @@ const char* USAGE =
 "  interval: <number> Time in seconds between samples (default 1).\n"
 "  filename: <string> Name of the file to log to (default stdout).\n";
 
-int handle_opts(int argc, char** argv, struct config_t* config)
+static int handle_opts(int argc, char** argv, struct config_t* config)
 {
     int c;
     int interval = 1;

--- a/examples/hiccup.c
+++ b/examples/hiccup.c
@@ -4,7 +4,6 @@
  * as explained at http://creativecommons.org/publicdomain/zero/1.0/
  */
 
-#define _GNU_SOURCE
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/hdr_encoding.c
+++ b/src/hdr_encoding.c
@@ -260,8 +260,8 @@ int hdr_base64_encode(
         return EINVAL;
     }
 
-    int i = 0;
-    int j = 0;
+    size_t i = 0;
+    size_t j = 0;
     for (; input_len - i >= 3 && j < output_len; i += 3, j += 4)
     {
         hdr_base64_encode_block(&input[i], &output[j]);
@@ -294,6 +294,8 @@ void hdr_base64_decode_block(const char* input, uint8_t* output)
 int hdr_base64_decode(
     const char* input, size_t input_len, uint8_t* output, size_t output_len)
 {
+	size_t i, j;
+
     if (input_len < 4 ||
         (input_len & 3) != 0 ||
         (input_len / 4) * 3 != output_len)
@@ -301,7 +303,7 @@ int hdr_base64_decode(
         return EINVAL;
     }
 
-    for (int i = 0, j = 0; i < input_len; i += 4, j += 3)
+    for (i = 0, j = 0; i < input_len; i += 4, j += 3)
     {
         hdr_base64_decode_block(&input[i], &output[j]);
     }

--- a/src/hdr_encoding.c
+++ b/src/hdr_encoding.c
@@ -7,6 +7,7 @@
 #include <math.h>
 
 #include "hdr_encoding.h"
+#include "hdr_tests.h"
 
 int zig_zag_encode_i64(uint8_t* buffer, int64_t signed_value)
 {
@@ -207,7 +208,7 @@ size_t hdr_base64_decoded_len(size_t encoded_size)
     return (encoded_size / 4) * 3;
 }
 
-void hdr_base64_encode_block_pad(const uint8_t* input, char* output, size_t pad)
+static void hdr_base64_encode_block_pad(const uint8_t* input, char* output, size_t pad)
 {
     uint32_t _24_bit_value = 0;
 

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -15,6 +15,7 @@
 #include <inttypes.h>
 
 #include "hdr_histogram.h"
+#include "hdr_tests.h"
 
 //  ######   #######  ##     ## ##    ## ########  ######  
 // ##    ## ##     ## ##     ## ###   ##    ##    ##    ## 
@@ -220,7 +221,7 @@ void hdr_reset_internal_counters(struct hdr_histogram* h)
     h->total_count = observed_total_count;
 }
 
-int32_t buckets_needed_to_cover_value(int64_t value, int32_t sub_bucket_count, int32_t unit_magnitude)
+static int32_t buckets_needed_to_cover_value(int64_t value, int32_t sub_bucket_count, int32_t unit_magnitude)
 {
     int64_t smallest_untrackable_value = ((int64_t) sub_bucket_count) << unit_magnitude;
     int32_t buckets_needed = 1;
@@ -686,7 +687,7 @@ bool hdr_iter_next(struct hdr_iter* iter)
 // ##        ##       ##    ##  ##    ## ##       ##   ###    ##     ##  ##       ##       ##    ##
 // ##        ######## ##     ##  ######  ######## ##    ##    ##    #### ######## ########  ######
 
-bool _percentile_iter_next(struct hdr_iter* iter)
+static bool _percentile_iter_next(struct hdr_iter* iter)
 {
     struct hdr_iter_percentiles* percentiles = &iter->specifics.percentiles;
 
@@ -772,7 +773,7 @@ static void format_line_string(char* str, size_t len, int significant_figures, f
 // ##     ## ########  ######   #######  ##     ## ########  ######## ########
 
 
-bool _recorded_iter_next(struct hdr_iter* iter)
+static bool _recorded_iter_next(struct hdr_iter* iter)
 {
     while (_basic_iter_next(iter))
     {
@@ -806,7 +807,7 @@ void hdr_iter_recorded_init(struct hdr_iter* iter, const struct hdr_histogram* h
 // ######## #### ##    ## ######## ##     ## ##     ##
 
 
-bool _iter_linear_next(struct hdr_iter* iter)
+static bool _iter_linear_next(struct hdr_iter* iter)
 {
     struct hdr_iter_linear* linear = &iter->specifics.linear;
 
@@ -862,7 +863,7 @@ void hdr_iter_linear_init(struct hdr_iter* iter, const struct hdr_histogram* h, 
 // ##       ##     ## ##    ##  ##     ## ##    ##   ##     ##    ##     ## ##     ##  ##  ##    ##
 // ########  #######   ######   ##     ## ##     ## ####    ##    ##     ## ##     ## ####  ######
 
-bool _log_iter_next(struct hdr_iter *iter)
+static bool _log_iter_next(struct hdr_iter *iter)
 {
     struct hdr_iter_log* logarithmic = &iter->specifics.log;
 

--- a/src/hdr_histogram_log.c
+++ b/src/hdr_histogram_log.c
@@ -422,7 +422,7 @@ static int hdr_decode_compressed_v0(
 
     int32_t compressed_length = be32toh(compression_flyweight->length);
 
-    if (compressed_length < 0 || length - sizeof(_compression_flyweight) < compressed_length)
+    if (compressed_length < 0 || length - sizeof(_compression_flyweight) < (size_t)compressed_length)
     {
         FAIL_AND_CLEANUP(cleanup, result, EINVAL);
     }
@@ -517,7 +517,7 @@ static int hdr_decode_compressed_v1(
 
     int32_t compressed_length = be32toh(compression_flyweight->length);
 
-    if (compressed_length < 0 || length - sizeof(_compression_flyweight) < compressed_length)
+    if (compressed_length < 0 || length - sizeof(_compression_flyweight) < (size_t)compressed_length)
     {
         FAIL_AND_CLEANUP(cleanup, result, EINVAL);
     }
@@ -615,7 +615,7 @@ static int hdr_decode_compressed_v2(
 
     int32_t compressed_length = be32toh(compression_flyweight->length);
 
-    if (compressed_length < 0 || length - sizeof(_compression_flyweight) < compressed_length)
+    if (compressed_length < 0 || length - sizeof(_compression_flyweight) < (size_t)compressed_length)
     {
         FAIL_AND_CLEANUP(cleanup, result, EINVAL);
     }
@@ -734,6 +734,7 @@ int hdr_decode_compressed(
 
 int hdr_log_writer_init(struct hdr_log_writer* writer)
 {
+	(void)writer;
     return 0;
 }
 
@@ -788,6 +789,8 @@ int hdr_log_write_header(
     struct hdr_log_writer* writer, FILE* file,
     const char* user_prefix, struct timespec* timestamp)
 {
+	(void)writer;
+
     if (print_user_prefix(file, user_prefix) < 0)
     {
         return EIO;
@@ -821,6 +824,8 @@ int hdr_log_write(
     int rc = 0;
     int result = 0;
     size_t encoded_len;
+
+	(void)writer;
 
     rc = hdr_encode_compressed(histogram, &compressed_histogram, &compressed_len);
     if (rc != 0)
@@ -980,6 +985,8 @@ int hdr_log_read(
     int end_ms = 0;
     int interval_max_s = 0;
     int interval_max_ms = 0;
+
+	(void)reader;
 
     ssize_t read = getline(&line, &line_len, file);
     if (-1 == read)

--- a/src/hdr_histogram_log.c
+++ b/src/hdr_histogram_log.c
@@ -20,6 +20,7 @@
 #include "hdr_encoding.h"
 #include "hdr_histogram.h"
 #include "hdr_histogram_log.h"
+#include "hdr_tests.h"
 
 #ifdef __APPLE__
 
@@ -54,7 +55,7 @@ int32_t counts_index_for(const struct hdr_histogram* h, int64_t value);
     }                       \
     while (0)
 
-int realloc_buffer(
+static int realloc_buffer(
     void** buffer, size_t nmemb, ssize_t size)
 {
     size_t len = nmemb * size;
@@ -86,7 +87,7 @@ int realloc_buffer(
 // ##    ##    ##    ##    ##   ##  ##   ### ##    ##  ##    ##
 //  ######     ##    ##     ## #### ##    ##  ######    ######
 
-ssize_t null_trailing_whitespace(char* s, ssize_t len)
+static ssize_t null_trailing_whitespace(char* s, ssize_t len)
 {
     ssize_t i = len;
     while (--i != -1)
@@ -121,12 +122,12 @@ static const int32_t V1_COMPRESSION_COOKIE = 0x1c849302;
 static const int32_t V2_ENCODING_COOKIE = 0x1c849303;
 static const int32_t V2_COMPRESSION_COOKIE = 0x1c849304;
 
-int32_t get_cookie_base(int32_t cookie)
+static int32_t get_cookie_base(int32_t cookie)
 {
     return (cookie & ~0xf0);
 }
 
-int32_t word_size_from_cookie(int32_t cookie)
+static int32_t word_size_from_cookie(int32_t cookie)
 {
     return (cookie & 0xf0) >> 4;
 }

--- a/src/hdr_histogram_log.c
+++ b/src/hdr_histogram_log.c
@@ -4,8 +4,6 @@
  * as explained at http://creativecommons.org/publicdomain/zero/1.0/
  */
 
-#define _GNU_SOURCE
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <inttypes.h>

--- a/src/hdr_tests.h
+++ b/src/hdr_tests.h
@@ -1,0 +1,15 @@
+#ifndef HDR_TESTS_H
+#define HDR_TESTS_H
+
+/* These are functions used in tests and are not intended for normal usage. */
+
+#include "hdr_histogram.h"
+
+void hdr_reset_internal_counters(struct hdr_histogram* h);
+int32_t counts_index_for(const struct hdr_histogram* h, int64_t value);
+int hdr_encode_compressed(struct hdr_histogram* h, uint8_t** compressed_histogram, size_t* compressed_len);
+int hdr_decode_compressed(uint8_t* buffer, size_t length, struct hdr_histogram** histogram);
+void hdr_base64_decode_block(const char* input, uint8_t* output);
+void hdr_base64_encode_block(const uint8_t* input, char* output);
+
+#endif

--- a/src/hdr_writer_reader_phaser.c
+++ b/src/hdr_writer_reader_phaser.c
@@ -14,17 +14,17 @@
 
 #include "hdr_writer_reader_phaser.h"
 
-int64_t _hdr_phaser_get_epoch(int64_t* field)
+static int64_t _hdr_phaser_get_epoch(int64_t* field)
 {
     return __atomic_load_n(field, __ATOMIC_SEQ_CST);
 }
 
-void _hdr_phaser_set_epoch(int64_t* field, int64_t val)
+static void _hdr_phaser_set_epoch(int64_t* field, int64_t val)
 {
     __atomic_store_n(field, val, __ATOMIC_SEQ_CST);
 }
 
-int64_t _hdr_phaser_reset_epoch(int64_t* field, int64_t initial_value)
+static int64_t _hdr_phaser_reset_epoch(int64_t* field, int64_t initial_value)
 {
     return __atomic_exchange_n(field, initial_value, __ATOMIC_SEQ_CST);
 }

--- a/test/hdr_histogram_log_test.c
+++ b/test/hdr_histogram_log_test.c
@@ -818,7 +818,7 @@ static struct mu_result all_tests()
     mu_ok;
 }
 
-int hdr_histogram_log_run_tests()
+static int hdr_histogram_log_run_tests()
 {
     struct mu_result result = all_tests();
 

--- a/test/hdr_histogram_log_test.c
+++ b/test/hdr_histogram_log_test.c
@@ -836,7 +836,7 @@ int hdr_histogram_log_run_tests()
     return result.message == NULL ? 0 : -1;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     return hdr_histogram_log_run_tests();
 }

--- a/test/hdr_histogram_perf.c
+++ b/test/hdr_histogram_perf.c
@@ -13,7 +13,7 @@
 
 #include "hdr_time.h"
 
-struct timespec diff(struct timespec start, struct timespec end)
+static struct timespec diff(struct timespec start, struct timespec end)
 {
     struct timespec temp;
     if ((end.tv_nsec-start.tv_nsec) < 0)
@@ -27,12 +27,6 @@ struct timespec diff(struct timespec start, struct timespec end)
         temp.tv_nsec = end.tv_nsec - start.tv_nsec;
     }
     return temp;
-}
-
-void inc(struct hdr_histogram* h, int32_t index, int64_t value)
-{
-    h->counts[index] += value;
-    h->total_count += value;
 }
 
 int main()

--- a/test/hdr_histogram_perf.c
+++ b/test/hdr_histogram_perf.c
@@ -35,7 +35,7 @@ void inc(struct hdr_histogram* h, int32_t index, int64_t value)
     h->total_count += value;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     struct hdr_histogram* histogram;
     int64_t max_value = INT64_C(24) * 60 * 60 * 1000000;

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -473,7 +473,7 @@ int hdr_histogram_run_tests()
     return result.message == NULL ? 0 : -1;
 }
 
-int main(int argc, char **argv)
+int main()
 {
     return hdr_histogram_run_tests();
 }

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -14,12 +14,12 @@
 
 #include "minunit.h"
 
-bool compare_values(double a, double b, double variation)
+static bool compare_values(double a, double b, double variation)
 {
     return compare_double(a, b, b * variation);
 }
 
-bool compare_percentile(int64_t a, double b, double variation)
+static bool compare_percentile(int64_t a, double b, double variation)
 {
     return compare_values((double) a, b, variation);
     // return fabs(a - b) <= b * variation;
@@ -425,7 +425,7 @@ static char* test_scaling_equivalence()
     return 0;
 }
 
-char* test_out_of_range_values()
+static char* test_out_of_range_values()
 {
     struct hdr_histogram *h;
     hdr_init(1, 1000, 4, &h);
@@ -455,7 +455,7 @@ static struct mu_result all_tests()
     mu_ok;
 }
 
-int hdr_histogram_run_tests()
+static int hdr_histogram_run_tests()
 {
     struct mu_result result = all_tests();
 

--- a/test/minunit.h
+++ b/test/minunit.h
@@ -44,7 +44,7 @@ struct mu_result
 
 extern int tests_run;
 
-bool compare_double(double a, double b, double delta)
+static bool compare_double(double a, double b, double delta)
 {
     if (fabs(a - b) < delta)
     {


### PR DESCRIPTION
I'm used to building with more warnings and sometimes need to compile with older compilers as well.