### PR TITLE
Add missing soname / version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,21 @@ endif()
 
 project("hdr_histogram")
 
+# Follow all steps below in order to calculate new ABI version when updating the library
+# NOTE: THIS IS UNRELATED to the actual project version
+#
+# 1. If the library source code has changed at all since the last update, then increment revision
+# 2. If any interfaces have been added, removed, or changed since the last update, increment current and set revision to 0.
+# 3. If any interfaces have been added since the last public release, then increment age.
+# 4. If any interfaces have been removed since the last public release, then set age to 0.
+
+set(HDR_SOVERSION_CURRENT   1)
+set(HDR_SOVERSION_REVISION  0)
+set(HDR_SOVERSION_AGE       0)
+
+set(HDR_VERSION ${HDR_SOVERSION_CURRENT}.${HDR_SOVERSION_AGE}.${HDR_SOVERSION_REVISION})
+set(HDR_SOVERSION ${HDR_SOVERSION_CURRENT})
+
 ENABLE_TESTING()
 
 if(UNIX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,13 @@ else()
     target_link_libraries(hdr_histogram_static m z)
 endif()
 
+if (WIN32)
+    set_target_properties(hdr_histogram PROPERTIES VERSION ${HDR_VERSION})
+else (WIN32)
+    set_target_properties(hdr_histogram PROPERTIES VERSION ${HDR_VERSION} SOVERSION ${HDR_SOVERSION})
+endif (WIN32)
+
+
 install(TARGETS hdr_histogram DESTINATION lib${LIB_SUFFIX})
 install(TARGETS hdr_histogram_static DESTINATION lib${LIB_SUFFIX})
 install(FILES hdr_histogram.h hdr_histogram_log.h hdr_time.h hdr_writer_reader_phaser.h hdr_interval_recorder.h DESTINATION include/hdr)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,6 @@ else()
     target_link_libraries(hdr_histogram_static m z)
 endif()
 
-install(TARGETS hdr_histogram DESTINATION lib)
-install(TARGETS hdr_histogram_static DESTINATION lib)
+install(TARGETS hdr_histogram DESTINATION lib${LIB_SUFFIX})
+install(TARGETS hdr_histogram_static DESTINATION lib${LIB_SUFFIX})
 install(FILES hdr_histogram.h hdr_histogram_log.h hdr_time.h hdr_writer_reader_phaser.h hdr_interval_recorder.h DESTINATION include/hdr)


### PR DESCRIPTION
First commit honors LIB_SUFFIX, which is mandatory for distribution using /usr/lib64

Second introduce soname version, which is mandatory for API/ABI compatibility tracking.
Of course, this means ABI have to be tracked in future release, and those value be  fixed.
