### PR TITLE
Use local include for hdr_thread.h

### DIFF
--- a/src/hdr_writer_reader_phaser.h
+++ b/src/hdr_writer_reader_phaser.h
@@ -10,8 +10,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <hdr_thread.h>
 #include <errno.h>
+
+#include "hdr_thread.h"
 
 HDR_ALIGN_PREFIX(8) 
 struct hdr_writer_reader_phaser


### PR DESCRIPTION
`#include <hdr_thread.h>` relies on hdr_thread.h being in the include path (ie, `.`), but `"hdr_thread.h"` looks in the same dir as the includer regardless.