### PR TITLE
Improved cmake script

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ else (WIN32)
     set_target_properties(hdr_histogram PROPERTIES VERSION ${HDR_VERSION} SOVERSION ${HDR_SOVERSION})
 endif (WIN32)
 
+target_include_directories(hdr_histogram SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(hdr_histogram_static SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS hdr_histogram DESTINATION lib${LIB_SUFFIX})
 install(TARGETS hdr_histogram_static DESTINATION lib${LIB_SUFFIX})


### PR DESCRIPTION
Added ability to avoid use `include_directories` in case of build HdrHistogram_c as sub-project in CMake based project.

Example:
```
add_subdirectory(deps/HdrHistogram_c)
...
add_executable(app main.cpp)
target_link_libraries(app hdr_histogram_static)
```
at this point you don't need `include_directories(deps/HdrHistogram_c/src)`

Thanks