### PR TITLE
Use a different clock to obtain the start time

### DIFF
--- a/examples/hiccup.c
+++ b/examples/hiccup.c
@@ -157,6 +157,7 @@ int main(int argc, char** argv)
     }
 
     hdr_gettime(&start_timestamp);
+    hdr_getnow(&timestamp);
     hdr_log_writer_init(&log_writer);
     hdr_log_write_header(&log_writer, output, "foobar", &timestamp);
 

--- a/src/hdr_time.c
+++ b/src/hdr_time.c
@@ -54,12 +54,22 @@ void hdr_gettime(hdr_timespec* ts)
     ts->tv_nsec = mts.tv_nsec;
 }
 
+
+void hdr_getnow(hdr_timespec* ts) {
+    hdr_gettime(ts);
+}
+
 #elif defined(__linux__) || defined(__CYGWIN__)
 
 
 void hdr_gettime(hdr_timespec* t)
 {
     clock_gettime(CLOCK_MONOTONIC, (struct timespec*)t);
+}
+
+void hdr_getnow(hdr_timespec* t)
+{
+    clock_gettime(CLOCK_REALTIME, (struct timespec*)t);
 }
 
 #else

--- a/src/hdr_time.h
+++ b/src/hdr_time.h
@@ -34,6 +34,8 @@ void hdr_gettime(hdr_timespec* t);
 void hdr_gettime(hdr_timespec* t);
 #endif
 
+void hdr_getnow(hdr_timespec* t);
+
 double hdr_timespec_as_double(const hdr_timespec* t);
 
 // Assumes only millisecond accuracy.


### PR DESCRIPTION
This code adds a new function, hdr_getnow which uses (on Linux) the CLOCK_REALTIME clock.

The hdr_gettime uses CLOCK_MONOTONIC, which relies on an unspecified point in time for its initial representation. Therefore, it is not suitable to find the actual point in time, since it may represent elapsed time since boot or others instead of Epoch.