### PR TITLE
Some small changes

### DIFF
--- a/src/hdr_histogram.h
+++ b/src/hdr_histogram.h
@@ -31,7 +31,7 @@ struct hdr_histogram
     double conversion_ratio;
     int32_t counts_len;
     int64_t total_count;
-    int64_t counts[0];
+    int64_t counts[1];
 };
 
 #ifdef __cplusplus

--- a/src/hdr_thread.h
+++ b/src/hdr_thread.h
@@ -46,7 +46,7 @@ void hdr_mutex_destroy(struct hdr_mutex* mutex);
 void hdr_mutex_lock(struct hdr_mutex* mutex);
 void hdr_mutex_unlock(struct hdr_mutex* mutex);
 
-void hdr_yield();
+void hdr_yield(void);
 int hdr_usleep(unsigned int useconds);
 
 #ifdef __cplusplus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 INCLUDE(CheckLibraryExists)
 
-add_executable(hdr_histogram_test hdr_histogram_test.c)
-add_executable(hdr_histogram_log_test hdr_histogram_log_test.c)
-add_executable(hdr_atomic_test hdr_atomic_test.c)
+add_executable(hdr_histogram_test hdr_histogram_test.c minunit.c)
+add_executable(hdr_histogram_log_test hdr_histogram_log_test.c minunit.c)
+add_executable(hdr_atomic_test hdr_atomic_test.c minunit.c)
 
 add_executable(perftest hdr_histogram_perf.c)
 

--- a/test/minunit.c
+++ b/test/minunit.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+
+#include "minunit.h"
+
+bool compare_double(double a, double b, double delta)
+{
+    if (fabs(a - b) < delta)
+    {
+        return true;
+    }
+    
+    printf("[compare_double] fabs(%f, %f) < %f == false\n", a, b, delta);
+    return false;
+}
+
+bool compare_int64(int64_t a, int64_t b)
+{
+    if (a == b)
+    {
+        return true;
+    }
+    
+    printf("[compare_int64] %" PRIu64 " == %" PRIu64 " == false\n", a, b);
+    return false;
+}

--- a/test/minunit.h
+++ b/test/minunit.h
@@ -45,7 +45,7 @@ struct mu_result
 
 extern int tests_run;
 
-static bool compare_double(double a, double b, double delta)
+static inline bool compare_double(double a, double b, double delta)
 {
     if (fabs(a - b) < delta)
     {
@@ -56,7 +56,7 @@ static bool compare_double(double a, double b, double delta)
     return false;
 }
 
-static bool compare_int64(int64_t a, int64_t b)
+static inline bool compare_int64(int64_t a, int64_t b)
 {
     if (a == b)
     {

--- a/test/minunit.h
+++ b/test/minunit.h
@@ -45,26 +45,8 @@ struct mu_result
 
 extern int tests_run;
 
-static bool compare_double(double a, double b, double delta)
-{
-    if (fabs(a - b) < delta)
-    {
-        return true;
-    }
+bool compare_double(double a, double b, double delta);
 
-    printf("[compare_double] fabs(%f, %f) < %f == false\n", a, b, delta);
-    return false;
-}
-
-static bool compare_int64(int64_t a, int64_t b)
-{
-    if (a == b)
-    {
-        return true;
-    }
-
-    printf("[compare_int64] %" PRIu64 " == %" PRIu64 " == false\n", a, b);
-    return false;
-}
+bool compare_int64(int64_t a, int64_t b);
 
 #endif

--- a/test/minunit.h
+++ b/test/minunit.h
@@ -45,7 +45,7 @@ struct mu_result
 
 extern int tests_run;
 
-static inline bool compare_double(double a, double b, double delta)
+static bool compare_double(double a, double b, double delta)
 {
     if (fabs(a - b) < delta)
     {
@@ -56,7 +56,7 @@ static inline bool compare_double(double a, double b, double delta)
     return false;
 }
 
-static inline bool compare_int64(int64_t a, int64_t b)
+static bool compare_int64(int64_t a, int64_t b)
 {
     if (a == b)
     {


### PR DESCRIPTION
I've seen compilation warnings on linux/osx when using this in C++, due to the zero length array. In addition, building the project causes some compilation warnings which i've also resolved.

I'm tidying up warnings as I want to use it in a 'warnings as errors' project. Hopefully these aren't contentious. The inline keyword is C99, so I wasn't sure if you were supporting earlier compilers.

Looks like inline is a step too far on windows, so i've removed it