### PR TITLE
Modified performance test to avoid unsupported tick (') format

### DIFF
--- a/test/hdr_histogram_perf.c
+++ b/test/hdr_histogram_perf.c
@@ -45,15 +45,13 @@ static char *format_double(double d)
 {
     static char buffer[30];
 
-    snprintf(buffer, 30, "%0.2f", d);
+    snprintf(buffer, sizeof(buffer), "%0.2f", d);
 
-    int length = strlen(buffer);
-
-    int p = length - 6;
+    int p = strlen(buffer) - 6;
 
     while (p > 0)
     {
-        memmove(buffer + p + 1, buffer + p, length - p + 1);
+        memmove(&buffer[p + 1], &buffer[p], strlen(buffer) - p + 1);
         buffer[p] = ',';
 
         p = p - 3;

--- a/test/hdr_histogram_perf.c
+++ b/test/hdr_histogram_perf.c
@@ -20,6 +20,7 @@
 #endif
 
 #include <windows.h>
+#define snprintf sprintf_s
 
 #endif
 
@@ -47,7 +48,7 @@ static char *format_double(double d)
 
     snprintf(buffer, sizeof(buffer), "%0.2f", d);
 
-    int p = strlen(buffer) - 6;
+    int p = (int) strlen(buffer) - 6;
 
     while (p > 0)
     {

--- a/test/hdr_histogram_perf.c
+++ b/test/hdr_histogram_perf.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include <hdr_histogram.h>
-#include <locale.h>
+#include <string.h>
 
 #include "hdr_time.h"
 
@@ -40,6 +40,28 @@ static hdr_timespec diff(hdr_timespec start, hdr_timespec end)
     return temp;
 }
 
+/* Formats the given double with 2 dps, and , thousand separators */
+static char *format_double(double d)
+{
+    static char buffer[30];
+
+    snprintf(buffer, 30, "%0.2f", d);
+
+    int length = strlen(buffer);
+
+    int p = length - 6;
+
+    while (p > 0)
+    {
+        memmove(buffer + p + 1, buffer + p, length - p + 1);
+        buffer[p] = ',';
+
+        p = p - 3;
+    }
+
+    return buffer;
+}
+
 int main()
 {
     struct hdr_histogram* histogram;
@@ -56,7 +78,6 @@ int main()
 
     hdr_timespec t0;
     hdr_timespec t1;
-    setlocale(LC_NUMERIC, "");
     int64_t iterations = 400000000;
 
     int i;
@@ -74,15 +95,7 @@ int main()
         double time_taken = taken.tv_sec + taken.tv_nsec / 1000000000.0;
         double ops_sec = (iterations - 1) / time_taken;
 
-#if defined(_MSC_VER)
-        wchar_t unformatted[64];
-        _snwprintf_s(unformatted, sizeof(unformatted), sizeof(unformatted) - 1, L"%.2f", ops_sec);
-        wchar_t formatted[64];
-        int ret = GetNumberFormatEx(LOCALE_NAME_USER_DEFAULT, 0, unformatted, NULL, formatted, sizeof(formatted));
-        wprintf_s(L"%s - %d, ops/sec: %s\n", L"Iteration", i + 1, formatted);
-#else
-        printf("%s - %d, ops/sec: %'.2f\n", "Iteration", i + 1, ops_sec);
-#endif
+        printf("%s - %d, ops/sec: %s\n", "Iteration", i + 1, format_double(ops_sec));
     }
 
     return 0;


### PR DESCRIPTION
I was seeing a build warning on linux/gcc about the use of the tick (') numeric formatter, so this implementation gives the same style output (thousand separators) but avoids the warning. It is cross platform and so removes the special windows code path which is nice.

The included function is a little specific (it won't work for negatives, and has the 2dps 'baked in'), but it was the simplest I could think of to give the same format.

An alternative would be to just drop the comma separated output, and revert to '%0.2f' for the numeric format, but keeping the output the same may be useful so I went with this option.

As this is a test app, the impact should be pretty low.