### PR TITLE
Hdr writer reader phaser leak fix

### DIFF
--- a/src/hdr_interval_recorder.c
+++ b/src/hdr_interval_recorder.c
@@ -35,7 +35,7 @@ int hdr_interval_recorder_init_all(
 
 void hdr_interval_recorder_destroy(struct hdr_interval_recorder* r)
 {
-    hdr_writer_reader_phaser_destory(&r->phaser);
+    hdr_writer_reader_phaser_destroy(&r->phaser);
 }
 
 void hdr_interval_recorder_update(

--- a/src/hdr_writer_reader_phaser.c
+++ b/src/hdr_writer_reader_phaser.c
@@ -56,7 +56,7 @@ int hdr_writer_reader_phaser_init(struct hdr_writer_reader_phaser* p)
     return 0;
 }
 
-void hdr_writer_reader_phaser_destory(struct hdr_writer_reader_phaser* p)
+void hdr_writer_reader_phaser_destroy(struct hdr_writer_reader_phaser* p)
 {
     hdr_mutex_destroy(p->reader_mutex);
     hdr_mutex_free(p->reader_mutex);

--- a/src/hdr_writer_reader_phaser.c
+++ b/src/hdr_writer_reader_phaser.c
@@ -59,6 +59,7 @@ int hdr_writer_reader_phaser_init(struct hdr_writer_reader_phaser* p)
 void hdr_writer_reader_phaser_destory(struct hdr_writer_reader_phaser* p)
 {
     hdr_mutex_destroy(p->reader_mutex);
+    hdr_mutex_free(p->reader_mutex);
 }
 
 int64_t hdr_phaser_writer_enter(struct hdr_writer_reader_phaser* p)

--- a/src/hdr_writer_reader_phaser.h
+++ b/src/hdr_writer_reader_phaser.h
@@ -30,7 +30,7 @@ extern "C" {
 
     int hdr_writer_reader_phaser_init(struct hdr_writer_reader_phaser* p);
 
-    void hdr_writer_reader_phaser_destory(struct hdr_writer_reader_phaser* p);
+    void hdr_writer_reader_phaser_destroy(struct hdr_writer_reader_phaser* p);
 
     int64_t hdr_phaser_writer_enter(struct hdr_writer_reader_phaser* p);
 


### PR DESCRIPTION
The writer reader phaser allocates a mutex, which is not freed when it is destroyed.  This pull request fixes that and also fixes a typo in the destructor function's name.