### PR TITLE
Fix leak in hdr_interval_recorder

### DIFF
--- a/examples/hiccup.c
+++ b/examples/hiccup.c
@@ -168,7 +168,7 @@ int main(int argc, char** argv)
     {        
         sleep(config.interval);
 
-        inactive = hdr_interval_recorder_sample_and_recycle(&recorder, inactive);
+        inactive = hdr_interval_recorder_sample(&recorder);
 
         hdr_gettime(&end_timestamp);
         timestamp = start_timestamp;

--- a/src/hdr_interval_recorder.c
+++ b/src/hdr_interval_recorder.c
@@ -9,6 +9,7 @@
 
 int hdr_interval_recorder_init(struct hdr_interval_recorder* r)
 {
+    r->active = r->inactive = NULL;
     return hdr_writer_reader_phaser_init(&r->phaser);
 }
 
@@ -18,6 +19,7 @@ int hdr_interval_recorder_init_all(
     int64_t highest_trackable_value,
     int significant_figures)
 {
+    r->active = r->inactive = NULL;
     int result = hdr_writer_reader_phaser_init(&r->phaser);
     result = result == 0
         ? hdr_init(lowest_trackable_value, highest_trackable_value, significant_figures, &r->active)
@@ -29,8 +31,12 @@ int hdr_interval_recorder_init_all(
 void hdr_interval_recorder_destroy(struct hdr_interval_recorder* r)
 {
     hdr_writer_reader_phaser_destroy(&r->phaser);
-    free(r->active);
-    free(r->inactive);
+    if (r->active) {
+        hdr_close(r->active);
+    }
+    if (r->inactive) {
+        hdr_close(r->inactive);
+    }
 }
 
 struct hdr_histogram* hdr_interval_recorder_sample_and_recycle(


### PR DESCRIPTION
Address sanitiser revealed a memory leak in hdr_interval_recorder. The leak was a consequence of using free instead of hdr_close in the hdr_interval_recorder_destroy function.

In addition, the active and inactive pointers should be set to null during hdr_interval_recorder initialisation.