### PR TITLE
docs: fix appveyor badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ HdrHistogram
 
 [![Gitter chat](https://badges.gitter.im/HdrHistogram/HdrHistogram.png)](https://gitter.im/HdrHistogram/HdrHistogram)
 
-Windows Build: ![AppVeyor](https://ci.appveyor.com/api/projects/status/github/HdrHistogram/HdrHistogram_c)
+Windows Build: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/HdrHistogram/HdrHistogram_c?svg=true)](https://ci.appveyor.com/project/mikeb01/hdrhistogram-c)
 
 Linux Build: [![Build Status](https://semaphoreci.com/api/v1/mikeb01/hdrhistogram_c/branches/master/badge.svg)](https://semaphoreci.com/mikeb01/hdrhistogram_c)
 


### PR DESCRIPTION
It was linking to the image instead of build log page.