### PR TITLE
hdr_close(): no-op if pointer is null

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -419,8 +419,10 @@ int hdr_init(
 
 void hdr_close(struct hdr_histogram* h)
 {
-    free(h->counts);
-    free(h);
+    if (h) {
+	free(h->counts);
+	free(h);
+    }
 }
 
 int hdr_alloc(int64_t highest_trackable_value, int significant_figures, struct hdr_histogram** result)


### PR DESCRIPTION
hdr_close() will segfault if it is passed a null pointer.  Typically, free()-like functions handle
"freeing an allocation that was never allocated" as a no-op, rather than erroring or crashing..  Otherwise, the caller has to be responsible to check themselves with every invocation.

This patch gates dereferencing `h` in order to free its members by first ensuring that `h`
itself is non-null.