### PR TITLE
Add support for OpenBSD

### DIFF
--- a/src/hdr_time.c
+++ b/src/hdr_time.c
@@ -60,7 +60,7 @@ void hdr_getnow(hdr_timespec* ts)
     hdr_gettime(ts);
 }
 
-#elif defined(__linux__) || defined(__CYGWIN__)
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__)
 
 
 void hdr_gettime(hdr_timespec* t)


### PR DESCRIPTION
OpenBSD supports clock_gettime() as it's used for Linux. Add macro test enabling clock_gettime() use on OpenBSD.