### PR TITLE
Fix installation folder for runtime

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,9 @@ function(hdr_histogram_add_library NAME LIBRARY_TYPE DO_INSTALL)
         install(
             TARGETS ${NAME}
             EXPORT ${PROJECT_NAME}-targets
-            DESTINATION ${CMAKE_INSTALL_LIBDIR})
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endif()
 endfunction()
 


### PR DESCRIPTION
On Windows, HdrHistogram installs dll file (if shared) in lib folder while it should go to bin folder. It's fixed in this PR.