### PR TITLE
Add the ability to change the HdrHistogram allocator at compile time.

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -17,6 +17,12 @@
 #include "hdr_tests.h"
 #include "hdr_atomic.h"
 
+#ifndef HDR_MALLOC_INCLUDE
+#define HDR_MALLOC_INCLUDE "hdr_malloc.h"
+#endif
+
+#include HDR_MALLOC_INCLUDE
+
 /*  ######   #######  ##     ## ##    ## ########  ######  */
 /* ##    ## ##     ## ##     ## ###   ##    ##    ##    ## */
 /* ##       ##     ## ##     ## ####  ##    ##    ##       */
@@ -398,16 +404,16 @@ int hdr_init(
         return r;
     }
 
-    counts = (int64_t*) calloc((size_t) cfg.counts_len, sizeof(int64_t));
+    counts = (int64_t*) hdr_calloc((size_t) cfg.counts_len, sizeof(int64_t));
     if (!counts)
     {
         return ENOMEM;
     }
 
-    histogram = (struct hdr_histogram*) calloc(1, sizeof(struct hdr_histogram));
+    histogram = (struct hdr_histogram*) hdr_calloc(1, sizeof(struct hdr_histogram));
     if (!histogram)
     {
-        free(counts);
+        hdr_free(counts);
         return ENOMEM;
     }
 
@@ -422,8 +428,8 @@ int hdr_init(
 void hdr_close(struct hdr_histogram* h)
 {
     if (h) {
-	free(h->counts);
-	free(h);
+	hdr_free(h->counts);
+	hdr_free(h);
     }
 }
 

--- a/src/hdr_interval_recorder.c
+++ b/src/hdr_interval_recorder.c
@@ -7,6 +7,12 @@
 #include "hdr_atomic.h"
 #include "hdr_interval_recorder.h"
 
+#ifndef HDR_MALLOC_INCLUDE
+#define HDR_MALLOC_INCLUDE "hdr_malloc.h"
+#endif
+
+#include HDR_MALLOC_INCLUDE
+
 int hdr_interval_recorder_init(struct hdr_interval_recorder* r)
 {
     r->active = r->inactive = NULL;

--- a/src/hdr_malloc.h
+++ b/src/hdr_malloc.h
@@ -1,0 +1,19 @@
+/**
+ * hdr_malloc.h
+ * Written by Filipe Oliveira and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * Allocator selection.
+ *
+ * This file is used in order to change the HdrHistogram allocator at compile time.
+ * Just define the following defines to what you want to use. Also add
+ * the include of your alternate allocator if needed (not needed in order
+ * to use the default libc allocator). */
+
+#ifndef HDR_ALLOC_H__
+#define HDR_ALLOC_H__
+#define hdr_malloc malloc
+#define hdr_calloc calloc
+#define hdr_realloc realloc
+#define hdr_free free
+#endif

--- a/src/hdr_thread.c
+++ b/src/hdr_thread.c
@@ -7,14 +7,20 @@
 #include <stdlib.h>
 #include "hdr_thread.h"
 
+#ifndef HDR_MALLOC_INCLUDE
+#define HDR_MALLOC_INCLUDE "hdr_malloc.h"
+#endif
+
+#include HDR_MALLOC_INCLUDE
+
 struct hdr_mutex* hdr_mutex_alloc(void)
 {
-    return malloc(sizeof(hdr_mutex));
+    return hdr_malloc(sizeof(hdr_mutex));
 }
 
 void hdr_mutex_free(struct hdr_mutex* mutex)
 {
-    free(mutex);
+    hdr_free(mutex);
 }
 
 #if defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)

--- a/src/hdr_writer_reader_phaser.c
+++ b/src/hdr_writer_reader_phaser.c
@@ -13,6 +13,12 @@
 
 #include "hdr_writer_reader_phaser.h"
 
+#ifndef HDR_MALLOC_INCLUDE
+#define HDR_MALLOC_INCLUDE "hdr_malloc.h"
+#endif
+
+#include HDR_MALLOC_INCLUDE
+
 static int64_t _hdr_phaser_get_epoch(int64_t* field)
 {
     return hdr_atomic_load_64(field);


### PR DESCRIPTION
This PR adds the ability to change the HdrHistogram allocator at compile time. 

The `hdr_malloc.h`  file is used in order to change the HdrHistogram allocator at compile time.
To alter the allocator just alter the following defines to what you want to use in `hdr_malloc.h`
```
#define hdr_malloc malloc
#define hdr_calloc calloc
#define hdr_realloc realloc
#define hdr_free free
```
Also add the include of your alternate allocator if needed (not needed in order to use the default libc allocator).