### PR TITLE
Added new API hdr_value_at_percentiles() as a means for redudant computation removal

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -670,25 +670,20 @@ int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile
 
 int hdr_value_at_percentiles(const struct hdr_histogram* h, const double* percentiles, const size_t N, int64_t** values)
 {
-    *values = (int64_t*) calloc((size_t) N, sizeof(int64_t));
     if (!*values)
     {
         return ENOMEM;
     }
-    int64_t* count_at_percentiles = (int64_t*) calloc((size_t) N, sizeof(int64_t));
-    if (!count_at_percentiles)
-    {
-        free(*values);
-        return ENOMEM;
-    }
     struct hdr_iter iter;
     const int64_t total_count = h->total_count;
+    // to avoid allocations we use the values array for intermediate computation
+    // i.e. to store the expected cumulative count at each percentile
     for (size_t i = 0; i < N; i++)
     {
         const double requested_percentile = percentiles[i] < 100.0 ? percentiles[i] : 100.0;
-        int64_t count_at_percentile =
+        const int64_t count_at_percentile =
         (int64_t) (((requested_percentile / 100) * total_count) + 0.5);
-        count_at_percentiles[i] = count_at_percentile > 1 ? count_at_percentile : 1;
+        (*values)[i] = count_at_percentile > 1 ? count_at_percentile : 1;
     }
 
     hdr_iter_init(&iter, h);
@@ -697,13 +692,12 @@ int hdr_value_at_percentiles(const struct hdr_histogram* h, const double* percen
     while (hdr_iter_next(&iter) && at_pos < N)
     {
         total += iter.count;
-        while (total >= count_at_percentiles[at_pos] && at_pos < N)
+        while (total >= (*values)[at_pos] && at_pos < N)
         {
             (*values)[at_pos] = highest_equivalent_value(h, iter.value);
             at_pos++;
         }
     }
-    free(count_at_percentiles);
     return 0;
 }
 

--- a/src/hdr_histogram.h
+++ b/src/hdr_histogram.h
@@ -273,6 +273,17 @@ int64_t hdr_max(const struct hdr_histogram* h);
 int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile);
 
 /**
+ * Get the values at the given percentiles.
+ *
+ * @param h "This" pointer.
+ * @param percentiles The ordered percentiles array to get the values for.
+ * @param N Number of elements in the arrays.
+ * @param values Destination array containg the values at the given percentiles.
+ * @return 0 on success, ENOMEM if malloc failed.
+ */
+int hdr_value_at_percentiles(const struct hdr_histogram* h, const double* percentiles, const size_t N, int64_t** values);
+
+/**
  * Gets the standard deviation for the values in the histogram.
  *
  * @param h "This" pointer

--- a/src/hdr_histogram.h
+++ b/src/hdr_histogram.h
@@ -278,8 +278,9 @@ int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile
  * @param h "This" pointer.
  * @param percentiles The ordered percentiles array to get the values for.
  * @param N Number of elements in the arrays.
- * @param values Destination array containg the values at the given percentiles.
- * @return 0 on success, ENOMEM if malloc failed.
+ * @param values Destination array containing the values at the given percentiles.
+ * The values array should be allocated by the caller.
+ * @return 0 on success, ENOMEM if the provided destination array is null.
  */
 int hdr_value_at_percentiles(const struct hdr_histogram* h, const double* percentiles, const size_t N, int64_t** values);
 

--- a/test/hdr_histogram_benchmark.cpp
+++ b/test/hdr_histogram_benchmark.cpp
@@ -4,63 +4,149 @@
 #include <random>
 
 #ifdef _WIN32
-#pragma comment ( lib, "Shlwapi.lib" )
+#pragma comment(lib, "Shlwapi.lib")
 #ifdef _DEBUG
-#pragma comment ( lib, "benchmarkd.lib" )
+#pragma comment(lib, "benchmarkd.lib")
 #else
-#pragma comment ( lib, "benchmark.lib" )
+#pragma comment(lib, "benchmark.lib")
 #endif
 #endif
 
 int64_t min_value = 1;
-int64_t min_precision = 1;
+int64_t min_precision = 3;
 int64_t max_precision = 4;
 int64_t min_time_unit = 1000;
 int64_t max_time_unit = 1000000;
 int64_t step_time_unit = 1000;
+int64_t generated_datapoints = 10000000;
 
-static void generate_arguments_pairs(benchmark::internal::Benchmark *b)
-{
-    for (int64_t precision = min_precision; precision <= max_precision; precision++)
-    {
-        for (int64_t time_unit = min_time_unit; time_unit <= max_time_unit; time_unit *= step_time_unit)
-        {
-            b = b->ArgPair(precision, INT64_C(24) * 60 * 60 * time_unit);
-        }
+static void generate_arguments_pairs(benchmark::internal::Benchmark *b) {
+  for (int64_t precision = min_precision; precision <= max_precision;
+       precision++) {
+    for (int64_t time_unit = min_time_unit; time_unit <= max_time_unit;
+         time_unit *= step_time_unit) {
+      b = b->ArgPair(precision, INT64_C(24) * 60 * 60 * time_unit);
     }
+  }
 }
 
-static void BM_hdr_init(benchmark::State &state)
-{
-    const int64_t precision = state.range(0);
-    const int64_t max_value = state.range(1);
-    for (auto _ : state)
-    {
-        struct hdr_histogram *histogram;
-        benchmark::DoNotOptimize(hdr_init(min_value, max_value, precision, &histogram));
-        // read/write barrier
-        benchmark::ClobberMemory();
-    }
-}
-
-static void BM_hdr_record_values(benchmark::State &state)
-{
-    const int64_t precision = state.range(0);
-    const int64_t max_value = state.range(1);
+static void BM_hdr_init(benchmark::State &state) {
+  const int64_t precision = state.range(0);
+  const int64_t max_value = state.range(1);
+  for (auto _ : state) {
     struct hdr_histogram *histogram;
-    hdr_init(min_value, max_value, precision, &histogram);
-    benchmark::DoNotOptimize(histogram->counts);
+    benchmark::DoNotOptimize(
+        hdr_init(min_value, max_value, precision, &histogram));
+    // read/write barrier
+    benchmark::ClobberMemory();
+  }
+}
 
-    for (auto _ : state)
-    {
-        benchmark::DoNotOptimize(hdr_record_values(histogram, 1000000, 1));
-        // read/write barrier
-        benchmark::ClobberMemory();
+static void BM_hdr_record_values(benchmark::State &state) {
+  const int64_t precision = state.range(0);
+  const int64_t max_value = state.range(1);
+  struct hdr_histogram *histogram;
+  hdr_init(min_value, max_value, precision, &histogram);
+  benchmark::DoNotOptimize(histogram->counts);
+
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(hdr_record_values(histogram, 1000000, 1));
+    // read/write barrier
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_hdr_value_at_percentile(benchmark::State &state) {
+  srand(12345);
+  const int64_t precision = state.range(0);
+  const int64_t max_value = state.range(1);
+  std::random_device rd;
+  std::mt19937 e2(rd());
+  std::uniform_real_distribution<> dist(0, 100);
+  std::default_random_engine generator;
+  // gama distribution shape 1 scale 100000
+  std::gamma_distribution<double> latency_gamma_dist(1.0, 100000);
+  struct hdr_histogram *histogram;
+  hdr_init(min_value, max_value, precision, &histogram);
+  for (int64_t i = 1; i < generated_datapoints; i++) {
+    int64_t number = int64_t(latency_gamma_dist(generator)) + 1;
+    number = number > max_value ? max_value : number;
+    hdr_record_value(histogram, number);
+  }
+  benchmark::DoNotOptimize(histogram->counts);
+  for (auto _ : state) {
+    state.PauseTiming();
+    const double percentile = dist(e2);
+    state.ResumeTiming();
+    benchmark::DoNotOptimize(hdr_value_at_percentile(histogram, percentile));
+    // read/write barrier
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_hdr_value_at_percentile_given_array(benchmark::State &state) {
+  srand(12345);
+  const int64_t precision = state.range(0);
+  const int64_t max_value = state.range(1);
+  const double percentile_list[4] = {50.0, 95.0, 99.0, 99.9};
+  std::default_random_engine generator;
+  // gama distribution shape 1 scale 100000
+  std::gamma_distribution<double> latency_gamma_dist(1.0, 100000);
+  struct hdr_histogram *histogram;
+  hdr_init(min_value, max_value, precision, &histogram);
+  for (int64_t i = 1; i < generated_datapoints; i++) {
+    int64_t number = int64_t(latency_gamma_dist(generator)) + 1;
+    number = number > max_value ? max_value : number;
+    hdr_record_value(histogram, number);
+  }
+  benchmark::DoNotOptimize(histogram->counts);
+  int64_t items_processed = 0;
+  for (auto _ : state) {
+    for (auto percentile : percentile_list) {
+      benchmark::DoNotOptimize(hdr_value_at_percentile(histogram, percentile));
+      // read/write barrier
+      benchmark::ClobberMemory();
     }
+    items_processed += 4;
+  }
+  state.SetItemsProcessed(items_processed);
+}
+
+static void BM_hdr_value_at_percentiles_given_array(benchmark::State &state) {
+  srand(12345);
+  const int64_t precision = state.range(0);
+  const int64_t max_value = state.range(1);
+  const double percentile_list[4] = {50.0, 95.0, 99.0, 99.9};
+  std::default_random_engine generator;
+  // gama distribution shape 1 scale 100000
+  std::gamma_distribution<double> latency_gamma_dist(1.0, 100000);
+  struct hdr_histogram *histogram;
+  hdr_init(min_value, max_value, precision, &histogram);
+  for (int64_t i = 1; i < generated_datapoints; i++) {
+    int64_t number = int64_t(latency_gamma_dist(generator)) + 1;
+    number = number > max_value ? max_value : number;
+    hdr_record_value(histogram, number);
+  }
+  benchmark::DoNotOptimize(histogram->counts);
+  int64_t *values;
+  benchmark::DoNotOptimize(values);
+  int64_t items_processed = 0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+        hdr_value_at_percentiles(histogram, percentile_list, 4, &values));
+    // read/write barrier
+    benchmark::ClobberMemory();
+    items_processed += 4;
+  }
+  state.SetItemsProcessed(items_processed);
 }
 
 // Register the functions as a benchmark
 BENCHMARK(BM_hdr_init)->Apply(generate_arguments_pairs);
 BENCHMARK(BM_hdr_record_values)->Apply(generate_arguments_pairs);
-
+BENCHMARK(BM_hdr_value_at_percentile)->Apply(generate_arguments_pairs);
+BENCHMARK(BM_hdr_value_at_percentile_given_array)
+    ->Apply(generate_arguments_pairs);
+BENCHMARK(BM_hdr_value_at_percentiles_given_array)
+    ->Apply(generate_arguments_pairs);
 BENCHMARK_MAIN();

--- a/test/hdr_histogram_benchmark.cpp
+++ b/test/hdr_histogram_benchmark.cpp
@@ -128,7 +128,7 @@ static void BM_hdr_value_at_percentiles_given_array(benchmark::State &state) {
     hdr_record_value(histogram, number);
   }
   benchmark::DoNotOptimize(histogram->counts);
-  int64_t *values;
+  int64_t *values = (int64_t*) malloc(4 * sizeof(int64_t));
   benchmark::DoNotOptimize(values);
   int64_t items_processed = 0;
   for (auto _ : state) {

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -224,6 +224,26 @@ static char* test_percentiles()
     return 0;
 }
 
+static char* test_percentiles_by_value_at_percentiles()
+{
+    load_histograms();
+    int64_t* values;
+    double percentiles[5]={30.0,99.0,99.99,99.999,100.0};
+    mu_assert("value_at_percentiles return should be 0", hdr_value_at_percentiles(raw_histogram,percentiles,5,&values) == 0);
+
+    mu_assert("Value at 30% not 1000.0",
+              compare_percentile(values[0], 1000.0, 0.001));
+    mu_assert("Value at 99% not 1000.0",
+              compare_percentile(values[1], 1000.0, 0.001));
+    mu_assert("Value at 99.99% not 1000.0",
+              compare_percentile(values[2], 1000.0, 0.001));
+    mu_assert("Value at 99.999% not 100000000.0",
+              compare_percentile(values[3], 100000000.0, 0.001));
+    mu_assert("Value at 100% not 100000000.0",
+              compare_percentile(values[4], 100000000.0, 0.001));
+    return 0;
+}
+
 
 static char* test_recorded_values()
 {
@@ -556,6 +576,7 @@ static struct mu_result all_tests()
     mu_run_test(test_get_min_value);
     mu_run_test(test_get_max_value);
     mu_run_test(test_percentiles);
+    mu_run_test(test_percentiles_by_value_at_percentiles);
     mu_run_test(test_recorded_values);
     mu_run_test(test_linear_values);
     mu_run_test(test_logarithmic_values);

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -227,7 +227,7 @@ static char* test_percentiles()
 static char* test_percentiles_by_value_at_percentiles()
 {
     load_histograms();
-    int64_t* values;
+    int64_t *values = (int64_t*) malloc(5 * sizeof(int64_t));
     double percentiles[5]={30.0,99.0,99.99,99.999,100.0};
     mu_assert("value_at_percentiles return should be 0", hdr_value_at_percentiles(raw_histogram,percentiles,5,&values) == 0);
 


### PR DESCRIPTION
# Problem definition


Thinking on the way we do latency percentile analysis, we normally require more than one percentile to be calculated for the given histogram at any given moment (example of p50, p95, p99, p999). 

If you look at the C function that provides the percentile calculation implementation you'll notice that we iterate over the counts array starting from 0 up until the we've reached a cumulative count of samples that represents or surpasses the requested percentile. 

## Sampling stack traces using perf

By profiling `hdr_value_at_percentile` symbol and annotate it we'll notice that 99% of the CPU cycles of `hdr_value_at_percentile` are spent on the iterator calculating the cumulative count up until we reach or surpass the count that represents the percentile.
<img width="1123" alt="perf-hdr_value_at_percentile" src="https://user-images.githubusercontent.com/5832149/107156913-fad22480-6978-11eb-87f5-b7103456e255.png">

<img width="808" alt="perf-hdr_value_at_percentile-annotated" src="https://user-images.githubusercontent.com/5832149/107156911-f9086100-6978-11eb-98eb-6d082055843d.png">


This means that if we want to compute p50 and p99, we could re-use the already precomputed comulative count that gives us the p50 and start from that value ( instead of starting again at 0 ) for calculating the p99, thus eliminating the redundant computation. 

## Adding the value_at_percentiles API

As seen above, when we want to compute multiple percentiles for a given histogram, we've identified a reusable partial results in `hdr_value_at_percentile` that is also where threads are spending most CPU cycles while running on-CPU. 

With that in mind, by adding a new API with the following signature and implementation, and assuming the user will follow the API pre-requesites (sorted percentiles array input) we should be able to deeply reduce redundant work and improve the overall function performance.

### new api function signature
```c
/**
 * Get the values at the given percentiles.
 *
 * @param h "This" pointer.
 * @param percentiles The ordered percentiles array to get the values for.
 * @param N Number of elements in the arrays.
 * @param values Destination array containg the values at the given percentiles.
 * @return 0 on success, ENOMEM if malloc failed.
 */
int hdr_value_at_percentiles(const struct hdr_histogram* h, const double* percentiles, const size_t N, int64_t** values);
```



### benchmarking the new API

Now that we've defined the new API, using the same setup code as the above microbenchmark, we should be able to deterministically and properly compare the optimization provided by eliminating the redundant computation.

New microbenchmark:

```c
static void BM_hdr_value_at_percentile_given_array(benchmark::State &state) {
  /////////////////////
  // benchmark setup //
  /////////////////////
  srand(12345);
  const int64_t precision = state.range(0);
  const int64_t max_value = state.range(1);
  const double percentile_list[4] = {50.0, 95.0, 99.0, 99.9};
  std::default_random_engine generator;
  // gama distribution shape 1 scale 100000
  std::gamma_distribution<double> latency_gamma_dist(1.0, 100000);
  struct hdr_histogram *histogram;
  hdr_init(min_value, max_value, precision, &histogram);
  for (int64_t i = 1; i < generated_datapoints; i++) {
    int64_t number = int64_t(latency_gamma_dist(generator)) + 1;
    number = number > max_value ? max_value : number;
    hdr_record_value(histogram, number);
  }
  benchmark::DoNotOptimize(histogram->counts);
  int64_t items_processed = 0;
  ///////////////////
  // benchmark run //
  ///////////////////
  for (auto _ : state) {
    for (auto percentile : percentile_list) {
      benchmark::DoNotOptimize(hdr_value_at_percentile(histogram, percentile));
      // read/write barrier
      benchmark::ClobberMemory();
    }
    items_processed += 4;
  }
  state.SetItemsProcessed(items_processed);
}
```

```
~/HdrHistogram_c/build$ ./test/hdr_histogram_benchmark --benchmark_filter=BM_hdr_value_at_percentile --benchmark_min_time=60
2021-02-07 16:55:23
Running ./test/hdr_histogram_benchmark
Run on (40 X 1227.32 MHz CPU s)
CPU Caches:
  L1 Data 32K (x20)
  L1 Instruction 32K (x20)
  L2 Unified 1024K (x20)
  L3 Unified 28160K (x1)
Load Average: 0.83, 0.37, 0.14
---------------------------------------------------------------------------------------------------------------
Benchmark                                                     Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------------------
BM_hdr_value_at_percentile_given_array/3/86400000        342337 ns       342335 ns       245263 items_per_second=11.6845k/s
BM_hdr_value_at_percentile_given_array/3/86400000000     343298 ns       343295 ns       245245 items_per_second=11.6518k/s
BM_hdr_value_at_percentile_given_array/4/86400000       3064091 ns      3064067 ns        27417 items_per_second=1.30545k/s
BM_hdr_value_at_percentile_given_array/4/86400000000    3062938 ns      3062914 ns        27379 items_per_second=1.30595k/s
BM_hdr_value_at_percentiles_given_array/3/86400000        107060 ns       107059 ns       786567 items_per_second=37.3625k/s
BM_hdr_value_at_percentiles_given_array/3/86400000000     107040 ns       107039 ns       783051 items_per_second=37.3694k/s
BM_hdr_value_at_percentiles_given_array/4/86400000       1043602 ns      1043592 ns        80462 items_per_second=3.83292k/s
BM_hdr_value_at_percentiles_given_array/4/86400000000    1043322 ns      1043312 ns        80458 items_per_second=3.83394k/s
```

# Benefits of hdr_value_at_percentiles() optimization as a means for redudant computation removal

As expected, by simply reusing intermediate computation and consequently reducing the redundant computation we've moved from taking 342 microseconds of CPU time to compute the 4 percentiles to 107 microseconds, and from a max of approximately 11.6K percentile calculations per second to 37.36K calculations per second, representing an 3.4X speedup ( dependent on both the number of percentiles to calculate and also the percentile and data distribution ).

The following chart visualize demonstrates the above optimization.


![perf-hdr_value_at_percentile_chart](https://user-images.githubusercontent.com/5832149/107156910-f7d73400-6978-11eb-8ae0-b74feff1003b.jpeg)


#### Used platform details

The performance results provided in this PR were collected using:
- **Hardware platform**: A physical HPE ProLiant DL380 Gen10 Server, with one Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz, Maximum memory capacity of 3 TB, disabling CPU Frequency Scaling and with all configurable BIOS and CPU system settings set to performance.
- **OS:** Ubuntu 18.04 Linux release 4.15.0-123. 
- **Installed Memory:** 64GB DDR4-SDRAM @ 2933 MHz
- **Compiler:** gcc-10 (Ubuntu 10.1.0-2ubuntu1~18.04) 10.1.0