### PR TITLE
Avoid reading past the end of the input buffer

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -699,7 +699,7 @@ int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percen
     while (hdr_iter_next(&iter) && at_pos < length)
     {
         total += iter.count;
-        while (total >= values[at_pos] && at_pos < length)
+        while (at_pos < length && total >= values[at_pos])
         {
             values[at_pos] = highest_equivalent_value(h, iter.value);
             at_pos++;


### PR DESCRIPTION
The loop condition may read past the input buffer. Usually, this
won't be a problem since the loop will terminate anyway. However,
this could be a problem if the following byte is at an address that
is not mapped, and it causes tools like ThreadSanitizer to
complain.

For the record: this bug was found using ThreadSanitizer.