### PR TITLE
Clean pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,8 @@ set(CPACK_GENERATOR "TGZ")
 include(CPack)
 
 if(${ZLIB_FOUND})
-    set(PC_LIBS_PRIVATE_ZLIB "-lz")
-    set(PC_REQUIRES_PRIVATE_ZLIB "zlib >= 1.2.11")
+    set(PC_REQUIRES_PRIVATE_ZLIB "zlib")
 else()
-    set(PC_LIBS_PRIVATE_ZLIB "")
     set(PC_REQUIRES_PRIVATE_ZLIB "")
 endif()
 configure_file(

--- a/hdr_histogram.pc.in
+++ b/hdr_histogram.pc.in
@@ -9,4 +9,4 @@ Version: @PROJECT_VERSION@
 Requires.private: @PC_REQUIRES_PRIVATE_ZLIB@
 Cflags: -I${includedir}
 Libs: -L${libdir} -l@PROJECT_NAME@
-Libs.private: -pthread -lm -lrt @PC_LIBS_PRIVATE_ZLIB@ -L${libdir}
+Libs.private: -pthread -lm -lrt -L${libdir}


### PR DESCRIPTION
This like breaks pkg-config usage on same old version (pkgconfig 0.27 on RHEL-7) and is not used