### PR TITLE
`hdr_value_at_percentile` optimization.

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -684,11 +684,13 @@ static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int
     int32_t bucket_idx = 0;
     int32_t bucket_base_idx = get_bucket_base_index(h, bucket_idx);
 
-    for (;;) {
-        if (count_to_idx >= count_at_percentile)
-        {
-            break;
-        }
+    // Overflow check
+    if (count_at_percentile > h->total_count)
+    {
+        count_at_percentile = h->total_count;
+    }
+
+    while (count_to_idx < count_at_percentile) {
         // increment bucket
         sub_bucket_idx++;
         if (sub_bucket_idx >= h->sub_bucket_count)

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -690,7 +690,8 @@ static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int
         count_at_percentile = h->total_count;
     }
 
-    while (count_to_idx < count_at_percentile) {
+    while (count_to_idx < count_at_percentile)
+    {
         // increment bucket
         sub_bucket_idx++;
         if (sub_bucket_idx >= h->sub_bucket_count)

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -165,6 +165,15 @@ static int32_t count_leading_zeros_64(int64_t value)
 #endif
 }
 
+static int64_t get_count_at_index_given_bucket_base_idx(const struct hdr_histogram* h, int32_t bucket_base_idx, int32_t sub_bucket_idx) {
+    return h->counts[bucket_base_idx+sub_bucket_idx-h->sub_bucket_half_count];
+}
+
+static int32_t get_bucket_base_index(const struct hdr_histogram* h, int32_t bucket_index)
+{
+    return (bucket_index + 1) << h->sub_bucket_half_count_magnitude;
+}
+
 static int32_t get_bucket_index(const struct hdr_histogram* h, int64_t value)
 {
     int32_t pow2ceiling = 64 - count_leading_zeros_64(value | h->sub_bucket_mask); /* smallest power of 2 containing value */
@@ -666,29 +675,40 @@ int64_t hdr_min(const struct hdr_histogram* h)
     return non_zero_min(h);
 }
 
+static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int64_t count_at_percentile ) {
+    int64_t count_to_idx = 0;
+    int64_t value_from_idx = 0;
+    int32_t sub_bucket_idx = -1;
+    int32_t bucket_idx = 0;
+    int32_t bucket_base_idx = get_bucket_base_index(h, bucket_idx);
+
+    for (;;) {
+        if (count_to_idx >= count_at_percentile) {
+            break;
+        }
+        // increment bucket
+        sub_bucket_idx++;
+        if (sub_bucket_idx >= h->sub_bucket_count) {
+            sub_bucket_idx = h->sub_bucket_half_count;
+            bucket_idx++;
+            bucket_base_idx = get_bucket_base_index(h, bucket_idx);
+        }
+        count_to_idx += get_count_at_index_given_bucket_base_idx(h, bucket_base_idx, sub_bucket_idx);
+        value_from_idx = ((int64_t)(sub_bucket_idx)) << (((int64_t)(bucket_idx))+h->unit_magnitude);
+    }
+    return value_from_idx;
+}
+
 int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile)
 {
-    struct hdr_iter iter;
-    int64_t total = 0;
     double requested_percentile = percentile < 100.0 ? percentile : 100.0;
     int64_t count_at_percentile =
         (int64_t) (((requested_percentile / 100) * h->total_count) + 0.5);
-    count_at_percentile = count_at_percentile > 1 ? count_at_percentile : 1;
-
-    hdr_iter_init(&iter, h);
-
-    while (hdr_iter_next(&iter))
-    {
-        total += iter.count;
-
-        if (total >= count_at_percentile)
-        {
-            int64_t value_from_index = iter.value;
-            return highest_equivalent_value(h, value_from_index);
-        }
+    int64_t value_from_idx = get_value_from_idx_up_to_count(h, count_at_percentile);
+    if (percentile == 0.0) {
+        return lowest_equivalent_value(h, value_from_idx);
     }
-
-    return 0;
+    return highest_equivalent_value(h, value_from_idx);
 }
 
 int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percentiles, int64_t *values, size_t length)

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -165,8 +165,9 @@ static int32_t count_leading_zeros_64(int64_t value)
 #endif
 }
 
-static int64_t get_count_at_index_given_bucket_base_idx(const struct hdr_histogram* h, int32_t bucket_base_idx, int32_t sub_bucket_idx) {
-    return h->counts[bucket_base_idx+sub_bucket_idx-h->sub_bucket_half_count];
+static int64_t get_count_at_index_given_bucket_base_idx(const struct hdr_histogram* h, int32_t bucket_base_idx, int32_t sub_bucket_idx)
+{
+    return h->counts[(bucket_base_idx + sub_bucket_idx) - h->sub_bucket_half_count];
 }
 
 static int32_t get_bucket_base_index(const struct hdr_histogram* h, int32_t bucket_index)
@@ -675,7 +676,8 @@ int64_t hdr_min(const struct hdr_histogram* h)
     return non_zero_min(h);
 }
 
-static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int64_t count_at_percentile ) {
+static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int64_t count_at_percentile )
+{
     int64_t count_to_idx = 0;
     int64_t value_from_idx = 0;
     int32_t sub_bucket_idx = -1;
@@ -683,18 +685,20 @@ static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int
     int32_t bucket_base_idx = get_bucket_base_index(h, bucket_idx);
 
     for (;;) {
-        if (count_to_idx >= count_at_percentile) {
+        if (count_to_idx >= count_at_percentile)
+        {
             break;
         }
         // increment bucket
         sub_bucket_idx++;
-        if (sub_bucket_idx >= h->sub_bucket_count) {
+        if (sub_bucket_idx >= h->sub_bucket_count)
+        {
             sub_bucket_idx = h->sub_bucket_half_count;
             bucket_idx++;
             bucket_base_idx = get_bucket_base_index(h, bucket_idx);
         }
         count_to_idx += get_count_at_index_given_bucket_base_idx(h, bucket_base_idx, sub_bucket_idx);
-        value_from_idx = ((int64_t)(sub_bucket_idx)) << (((int64_t)(bucket_idx))+h->unit_magnitude);
+        value_from_idx = ((int64_t)(sub_bucket_idx)) << (((int64_t)(bucket_idx)) + h->unit_magnitude);
     }
     return value_from_idx;
 }
@@ -705,7 +709,8 @@ int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile
     int64_t count_at_percentile =
         (int64_t) (((requested_percentile / 100) * h->total_count) + 0.5);
     int64_t value_from_idx = get_value_from_idx_up_to_count(h, count_at_percentile);
-    if (percentile == 0.0) {
+    if (percentile == 0.0)
+    {
         return lowest_equivalent_value(h, value_from_idx);
     }
     return highest_equivalent_value(h, value_from_idx);

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -676,7 +676,7 @@ int64_t hdr_min(const struct hdr_histogram* h)
     return non_zero_min(h);
 }
 
-static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int64_t count_at_percentile )
+static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int64_t count_at_percentile)
 {
     int64_t count_to_idx = 0;
     int64_t value_from_idx = 0;

--- a/test/hdr_histogram_benchmark.cpp
+++ b/test/hdr_histogram_benchmark.cpp
@@ -1,5 +1,5 @@
 #include <benchmark/benchmark.h>
-#include <hdr_histogram.h>
+#include <hdr/hdr_histogram.h>
 #include <math.h>
 #include <random>
 

--- a/test/hdr_histogram_benchmark.cpp
+++ b/test/hdr_histogram_benchmark.cpp
@@ -1,5 +1,5 @@
 #include <benchmark/benchmark.h>
-#include <hdr/hdr_histogram.h>
+#include <hdr_histogram.h>
 #include <math.h>
 #include <random>
 


### PR DESCRIPTION
This is basically a C port of the optimization in PR https://github.com/HdrHistogram/hdrhistogram-go/pull/48 by @filipecosta90.

before:
```
yoav@yoav-thinkpad:~/HdrHistogram_c/build$ ./test/hdr_histogram_benchmark --benchmark_filter=BM_hdr_value_at_percentile/3/86400000 --benchmark_min_time=10
2022-03-21 12:41:46
Running ./test/hdr_histogram_benchmark
Run on (12 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 256K (x6)
  L3 Unified 12288K (x1)
Load Average: 0.68, 0.81, 0.89
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_hdr_value_at_percentile/3/86400000         34937 ns        34955 ns       404859
BM_hdr_value_at_percentile/3/86400000000      36561 ns        36581 ns       398987
```
after:
```
yoav@yoav-thinkpad:~/HdrHistogram_c/build$ ./test/hdr_histogram_benchmark --benchmark_filter=BM_hdr_value_at_percentile/3/86400000 --benchmark_min_time=10
2022-03-21 13:36:17
Running ./test/hdr_histogram_benchmark
Run on (12 X 4600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x6)
  L1 Instruction 32K (x6)
  L2 Unified 256K (x6)
  L3 Unified 12288K (x1)
Load Average: 0.86, 0.96, 1.26
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_hdr_value_at_percentile/3/86400000          5070 ns         5083 ns      2795009
BM_hdr_value_at_percentile/3/86400000000       5124 ns         5135 ns      2753732
```