### PR TITLE
Some intrinsics are not available in clang/win/arm

### DIFF
--- a/src/hdr_atomic.h
+++ b/src/hdr_atomic.h
@@ -8,7 +8,7 @@
 #define HDR_ATOMIC_H__
 
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !(defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64)))
 
 #include <stdint.h>
 #include <intrin.h>

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -133,7 +133,7 @@ static int64_t power(int64_t base, int64_t exp)
     return result;
 }
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !(defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64)))
 #   if defined(_WIN64)
 #       pragma intrinsic(_BitScanReverse64)
 #   else
@@ -143,7 +143,7 @@ static int64_t power(int64_t base, int64_t exp)
 
 static int32_t count_leading_zeros_64(int64_t value)
 {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !(defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64)))
     uint32_t leading_zero = 0;
 #if defined(_WIN64)
     _BitScanReverse64(&leading_zero, value);


### PR DESCRIPTION
When compiling for Windows ARM/ARM64 with clang, intrinsics like _ReadBarrier, _WriteBarrier, _BitScanReverse are not available.