### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool zlib1g-dev
+
+COPY . $SRC/hdrhistogram_c
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/hdrhistogram_c

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,17 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+
+To reproduce this set up the way ClusterFuzzLite does it (by way of [OSS-Fuzz](https://github.com/google/oss-fuzz)) you can do:
+
+```sh
+git clone https://github.com/google/oss-fuzz
+git clone https://github.com/HdrHistogram/HdrHistogram_c hdrhistogram_c
+cd hdrhistogram_c
+
+# Build the fuzzers in .clusterfuzzlite
+python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD
+
+# Run the fuzzer for 10 seconds
+python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD log_reader_fuzzer -- -max_total_time=10
+```

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# Use the following environment variables to build the code
+# $CXX:               c++ compiler
+# $CC:                c compiler
+# CFLAGS:             compiler flags for C files
+# CXXFLAGS:           compiler flags for CPP files
+# LIB_FUZZING_ENGINE: linker flag for fuzzing harnesses
+
+mkdir build
+cd build
+cmake ../
+make
+
+# Build and copy fuzzer executables to $OUT/
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/hdrhistogram_c/.clusterfuzzlite/log_reader_fuzzer.c \
+  -o $OUT/log_reader_fuzzer \
+  -I$SRC/hdrhistogram_c/include \
+  $SRC/hdrhistogram_c/build/src/libhdr_histogram_static.a -l:libz.a
+
+# Prepare corpus
+zip -j $OUT/log_reader_fuzzer_seed_corpus.zip $SRC/hdrhistogram_c/test/*.hlog

--- a/.clusterfuzzlite/log_reader_fuzzer.c
+++ b/.clusterfuzzlite/log_reader_fuzzer.c
@@ -1,0 +1,62 @@
+#include <hdr/hdr_histogram.h>
+#include <hdr/hdr_histogram_log.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char filename[256];
+  hdr_timespec timestamp, interval;
+  struct hdr_histogram *h = NULL;
+  struct hdr_log_reader reader;
+  int rc = 0;
+
+  sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+  FILE *fp = fopen(filename, "wb");
+  if (!fp) {
+    return 0;
+  }
+  fwrite(data, size, 1, fp);
+  fclose(fp);
+
+  // open FP to the log file
+  fp = fopen(filename, "r");
+  if (hdr_log_reader_init(&reader)) {
+    return 0;
+  }
+
+  rc = hdr_log_read_header(&reader, fp);
+  if (rc) {
+    fclose(fp);
+    unlink(filename);
+    return 0;
+  }
+
+  // Output to /dev/null
+  FILE *fp_dev_null = fopen("/dev/null", "w");
+
+  rc = hdr_log_read(&reader, fp, &h, &timestamp, &interval);
+
+  if (0 == rc) {
+    // Call functions used by NodeJS
+    hdr_min(h);
+    hdr_max(h);
+    hdr_mean(h);
+    hdr_stddev(h);
+    hdr_value_at_percentile(h, 50.0);
+    hdr_get_memory_size(h);
+
+    hdr_percentiles_print(h, fp_dev_null, 5, 1.0, CLASSIC);
+    hdr_close(h);
+  }
+
+  fclose(fp_dev_null);
+  fclose(fp);
+
+  unlink(filename);
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 200
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of
[ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.