### PR TITLE
hdr_historgram_log: fix 3 memory leaks on histogram-counts

### DIFF
--- a/src/hdr_histogram_log.c
+++ b/src/hdr_histogram_log.c
@@ -440,7 +440,7 @@ cleanup:
 
     if (result != 0)
     {
-        hdr_free(h);
+        hdr_close(h);
     }
     else if (NULL == *histogram)
     {
@@ -541,7 +541,7 @@ cleanup:
 
     if (result != 0)
     {
-        hdr_free(h);
+        hdr_close(h);
     }
     else if (NULL == *histogram)
     {
@@ -643,7 +643,7 @@ cleanup:
 
     if (result != 0)
     {
-        hdr_free(h);
+        hdr_close(h);
     }
     else if (NULL == *histogram)
     {


### PR DESCRIPTION
The fuzzer from https://github.com/HdrHistogram/HdrHistogram_c/pull/120 found some leaks when the `hdr_decode_compressed*` functions call `hdr_init` but later fails and cleans up `h` by way of `hdr_free(h)`. The problem is that the `counts` field on the histogram is leaked, which is allocated here:
https://github.com/HdrHistogram/HdrHistogram_c/blob/8dcce8f68512fca460b171bccc3a5afce0048779/src/hdr_histogram.c#L424 and assigned to the `counts` field here:
https://github.com/HdrHistogram/HdrHistogram_c/blob/8dcce8f68512fca460b171bccc3a5afce0048779/src/hdr_histogram.c#L437

Instead of using `hdr_free` the cleanup function should be `hdr_close: https://github.com/HdrHistogram/HdrHistogram_c/blob/8dcce8f68512fca460b171bccc3a5afce0048779/src/hdr_histogram.c#L445-L451