### PR TITLE
Cmake patches

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ function(hdr_histogram_add_library NAME LIBRARY_TYPE DO_INSTALL)
         ${NAME}
         PUBLIC
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hdr>)
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     if(DO_INSTALL)
         install(
             TARGETS ${NAME}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,9 @@ function(hdr_histogram_add_library NAME LIBRARY_TYPE DO_INSTALL)
         PUBLIC
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+    add_library(${PROJECT_NAME}::${NAME} ALIAS ${NAME})
+
     if(DO_INSTALL)
         install(
             TARGETS ${NAME}


### PR DESCRIPTION
Possible solution for #127 and #128.

I'm not sure if there is cases where modifying the `INSTALL_INTERFACE` breaks downstream projects. As mentioned in #127, the reason I think it works is because of the compiler's built-in include path and for those cases, to modification should make no difference. 