### PR TITLE
Fix ClangCL build on Windows

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -37,7 +37,7 @@
 /* Runtime-dispatched AVX2 path: keep the rest of this TU at the project's
    baseline ISA so the shipped binary does not silently require AVX2. */
 #if (defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)) \
-    && (defined(__GNUC__) || defined(__clang__)) && !defined(__INTEL_COMPILER)
+    && (defined(__GNUC__) || defined(__clang__)) && !defined(__INTEL_COMPILER) && !defined(_MSC_VER)
 #  define HDR_HAS_AVX2_DISPATCH 1
 #  include <immintrin.h>
 #endif


### PR DESCRIPTION
This problem was detected when updating the Histogram dependency in Node.js in [this PR](https://github.com/nodejs/node/pull/64296). The patch worked locally when building Node, so I am opening this PR to push it upstream.