### PR TITLE
fix: signed-overflow UB in top-bucket value-range math (hdr_max/percentile/iterator)

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -291,7 +291,17 @@ static int64_t lowest_equivalent_value_given_bucket_indices(
 
 int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t value)
 {
-    return lowest_equivalent_value(h, value) + hdr_size_of_equivalent_value_range(h, value);
+    int64_t low  = lowest_equivalent_value(h, value);
+    int64_t size = hdr_size_of_equivalent_value_range(h, value);
+    /* For a value in the top bucket, low + size can exceed INT64_MAX, which is
+       signed-overflow UB. Saturate instead; highest_equivalent_value() then
+       returns INT64_MAX - 1 for the top bucket rather than overflowing. This
+       feeds hdr_max / hdr_value_at_percentile / hdr_percentiles_print. */
+    if (low > INT64_MAX - size)
+    {
+        return INT64_MAX;
+    }
+    return low + size;
 }
 
 static int64_t highest_equivalent_value(const struct hdr_histogram* h, int64_t value)
@@ -915,7 +925,14 @@ static bool move_next(struct hdr_iter* iter)
         iter->h, bucket_index, sub_bucket_index);
     iter->lowest_equivalent_value = leq;
     iter->value = value;
-    iter->highest_equivalent_value = leq + size_of_equivalent_value_range - 1;
+    /* Saturate: for the top bucket leq + size overflows int64 (UB). The
+       all-values iterator visits every bucket, so this fires on any full
+       iteration (hdr_stddev, hdr_percentiles_print, ...) of a histogram whose
+       highest_trackable_value is near INT64_MAX. */
+    iter->highest_equivalent_value =
+        (leq > INT64_MAX - size_of_equivalent_value_range)
+            ? INT64_MAX
+            : leq + size_of_equivalent_value_range - 1;
     iter->median_equivalent_value = leq + (size_of_equivalent_value_range >> 1);
 
     return true;

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -293,10 +293,7 @@ int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t val
 {
     int64_t low  = lowest_equivalent_value(h, value);
     int64_t size = hdr_size_of_equivalent_value_range(h, value);
-    /* For a value in the top bucket, low + size can exceed INT64_MAX, which is
-       signed-overflow UB. Saturate instead; highest_equivalent_value() then
-       returns INT64_MAX - 1 for the top bucket rather than overflowing. This
-       feeds hdr_max / hdr_value_at_percentile / hdr_percentiles_print. */
+    /* saturate: top-bucket low+size overflows int64 (UB) */
     if (low > INT64_MAX - size)
     {
         return INT64_MAX;
@@ -306,7 +303,14 @@ int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t val
 
 static int64_t highest_equivalent_value(const struct hdr_histogram* h, int64_t value)
 {
-    return hdr_next_non_equivalent_value(h, value) - 1;
+    int64_t low  = lowest_equivalent_value(h, value);
+    int64_t size = hdr_size_of_equivalent_value_range(h, value);
+    /* clamp: top-bucket low+size-1 overflows int64; keep value <= highest_equivalent_value */
+    if (low > INT64_MAX - size)
+    {
+        return INT64_MAX;
+    }
+    return low + size - 1;
 }
 
 int64_t hdr_median_equivalent_value(const struct hdr_histogram *h, int64_t value)
@@ -925,10 +929,7 @@ static bool move_next(struct hdr_iter* iter)
         iter->h, bucket_index, sub_bucket_index);
     iter->lowest_equivalent_value = leq;
     iter->value = value;
-    /* Saturate: for the top bucket leq + size overflows int64 (UB). The
-       all-values iterator visits every bucket, so this fires on any full
-       iteration (hdr_stddev, hdr_percentiles_print, ...) of a histogram whose
-       highest_trackable_value is near INT64_MAX. */
+    /* saturate: top-bucket leq+size overflows int64 (UB) */
     iter->highest_equivalent_value =
         (leq > INT64_MAX - size_of_equivalent_value_range)
             ? INT64_MAX

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <math.h>
 
 #include <stdio.h>
 #include <hdr/hdr_histogram.h>
@@ -575,18 +576,22 @@ static char* test_top_bucket_value_range_no_overflow(void)
     hdr_record_value(h, INT64_MAX);
     hdr_record_value(h, 5);
 
-    /* The top bucket saturates to INT64_MAX; a recorded INT64_MAX must not
-       report a max below itself (invariant value <= highest_equivalent_value). */
-    mu_assert("max saturates to INT64_MAX", INT64_MAX == hdr_max(h));
-    mu_assert("p100 saturates to INT64_MAX", INT64_MAX == hdr_value_at_percentile(h, 100.0));
-    /* Plain-build guard: on the buggy code low + size overflows and
-       hdr_next_non_equivalent_value(INT64_MAX) wraps to INT64_MIN. */
+    /* hdr_next_non_equivalent_value is the only assertion here that distinguishes
+       fixed from broken on a plain (non-UBSan) build: on the buggy code low + size
+       overflows and hdr_next_non_equivalent_value(INT64_MAX) wraps to INT64_MIN,
+       whereas the fix saturates to INT64_MAX. */
     mu_assert("next_non_equivalent_value saturates, not wrapped negative",
               INT64_MAX == hdr_next_non_equivalent_value(h, INT64_MAX));
-    mu_assert("stddev is finite", hdr_stddev(h) == hdr_stddev(h));
+    /* The remaining checks pass on the unfixed code too (the overflow is UB but
+       happens to produce these values on common targets); they are UBSan-only
+       guards against the signed-overflow itself, plus invariant/sanity pins. */
+    mu_assert("max saturates to INT64_MAX", INT64_MAX == hdr_max(h));
+    mu_assert("p100 saturates to INT64_MAX", INT64_MAX == hdr_value_at_percentile(h, 100.0));
+    mu_assert("stddev is finite", isfinite(hdr_stddev(h)));
 
     /* The all-values iterator visits the top bucket; its highest_equivalent_value
-       must stay a representable non-negative int64 (was an overflowed value). */
+       must stay a representable non-negative int64 (UBSan-only guard: the overflow
+       is UB, but the wrapped value is typically still >= 0 on a plain build). */
     hdr_iter_init(&iter, h);
     while (hdr_iter_next(&iter))
     {

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -561,6 +561,37 @@ static char* reset_histogram_on_sample_and_recycle(void)
     return 0;
 }
 
+static char* test_top_bucket_value_range_no_overflow(void)
+{
+    /* Regression (UBSan, found via fuzzing): for a histogram whose
+       highest_trackable_value is near INT64_MAX, the top bucket's
+       lowest_equivalent + size_of_equivalent_value_range overflowed int64,
+       corrupting hdr_max / hdr_value_at_percentile / hdr_stddev and the
+       all-values iterator. Those value-range computations now saturate. */
+    struct hdr_histogram* h = NULL;
+    struct hdr_iter iter;
+
+    mu_assert("Should allocate", 0 == hdr_init(1, INT64_MAX, 3, &h));
+    hdr_record_value(h, INT64_MAX);
+    hdr_record_value(h, 5);
+
+    mu_assert("max is representable and non-negative", hdr_max(h) > 0);
+    mu_assert("p100 is representable and non-negative", hdr_value_at_percentile(h, 100.0) > 0);
+    mu_assert("stddev is finite", hdr_stddev(h) == hdr_stddev(h));
+
+    /* A full iteration visits the top bucket; highest_equivalent_value must
+       stay a representable non-negative int64 (was a negative/overflowed value). */
+    hdr_iter_init(&iter, h);
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("iter highest_equivalent_value stays representable",
+                  iter.highest_equivalent_value >= 0);
+    }
+
+    hdr_close(h);
+    return 0;
+}
+
 static struct mu_result all_tests(void)
 {
     mu_run_test(test_create);
@@ -570,6 +601,7 @@ static struct mu_result all_tests(void)
     mu_run_test(test_total_count);
     mu_run_test(test_get_min_value);
     mu_run_test(test_get_max_value);
+    mu_run_test(test_top_bucket_value_range_no_overflow);
     mu_run_test(test_percentiles);
     mu_run_test(test_percentiles_by_value_at_percentiles);
     mu_run_test(test_recorded_values);

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -575,12 +575,18 @@ static char* test_top_bucket_value_range_no_overflow(void)
     hdr_record_value(h, INT64_MAX);
     hdr_record_value(h, 5);
 
-    mu_assert("max is representable and non-negative", hdr_max(h) > 0);
-    mu_assert("p100 is representable and non-negative", hdr_value_at_percentile(h, 100.0) > 0);
+    /* The top bucket saturates to INT64_MAX; a recorded INT64_MAX must not
+       report a max below itself (invariant value <= highest_equivalent_value). */
+    mu_assert("max saturates to INT64_MAX", INT64_MAX == hdr_max(h));
+    mu_assert("p100 saturates to INT64_MAX", INT64_MAX == hdr_value_at_percentile(h, 100.0));
+    /* Plain-build guard: on the buggy code low + size overflows and
+       hdr_next_non_equivalent_value(INT64_MAX) wraps to INT64_MIN. */
+    mu_assert("next_non_equivalent_value saturates, not wrapped negative",
+              INT64_MAX == hdr_next_non_equivalent_value(h, INT64_MAX));
     mu_assert("stddev is finite", hdr_stddev(h) == hdr_stddev(h));
 
-    /* A full iteration visits the top bucket; highest_equivalent_value must
-       stay a representable non-negative int64 (was a negative/overflowed value). */
+    /* The all-values iterator visits the top bucket; its highest_equivalent_value
+       must stay a representable non-negative int64 (was an overflowed value). */
     hdr_iter_init(&iter, h);
     while (hdr_iter_next(&iter))
     {


### PR DESCRIPTION
## In-contract int64 overflow in top-bucket value-range math, found by adversarial review during the ClusterFuzzLite effort

For a histogram whose `highest_trackable_value` is near `INT64_MAX`, the **top bucket's** `lowest_equivalent_value + size_of_equivalent_value_range` exceeds `INT64_MAX` → signed-overflow UB. Two arithmetic sites:

- `hdr_next_non_equivalent_value` (`:294`) and `highest_equivalent_value` (`:307`) → poisons **`hdr_max`**, **`hdr_value_at_percentile`**, and the value-range lines of **`hdr_percentiles_print`**.
- `move_next` (`:918`, the all-values iterator, which visits every bucket regardless of counts) → the iterator's `highest_equivalent_value`.

In-contract (`hdr_init` accepts up to `INT64_MAX`) and reachable from an untrusted decoded log (decode → `hdr_reset_internal_counters` → `highest_equivalent_value`; and `log_reader_fuzzer` calls `hdr_max`/`hdr_value_at_percentile` on every decoded histogram).

### Fix
Saturate all three value-range computations at `INT64_MAX` instead of overflowing. `highest_equivalent_value` gets its own overflow-aware clamp (not `next_non_equivalent - 1`), so `hdr_max` of a histogram that recorded `INT64_MAX` correctly returns `INT64_MAX` and agrees with the iterator path.

### Scope (precise)
This PR fixes the **value-range** additions only. The related `hdr_mean` `count * value` overflow (which also feeds `hdr_stddev` and the `hdr_percentiles_print` CLASSIC footer) is a **separate** overflow class fixed in the companion **#147**. Both are needed for a fully overflow-free read path on near-`INT64_MAX` histograms. The linear/log iterator reporting-level overflows are addressed separately (follow-up PR).

### Verification
Under ASan+UBSan: `hdr_max` / percentiles / value-range iteration no longer trap and return representable values (`INT64_MAX`); normal histograms are byte-identical (guard only triggers on genuine top-bucket overflow). Regression test added and pins the saturated values. Full suite green.

> The ASan/UBSan `ctest` CI job that makes these regression tests deterministic guards is in #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)