### PR TITLE
fix: int64 overflow in linear/log iterator reporting level (near INT64_MAX)

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -291,7 +291,17 @@ static int64_t lowest_equivalent_value_given_bucket_indices(
 
 int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t value)
 {
-    return lowest_equivalent_value(h, value) + hdr_size_of_equivalent_value_range(h, value);
+    int64_t low  = lowest_equivalent_value(h, value);
+    int64_t size = hdr_size_of_equivalent_value_range(h, value);
+    /* For a value in the top bucket, low + size can exceed INT64_MAX, which is
+       signed-overflow UB. Saturate instead; highest_equivalent_value() then
+       returns INT64_MAX - 1 for the top bucket rather than overflowing. This
+       feeds hdr_max / hdr_value_at_percentile / hdr_percentiles_print. */
+    if (low > INT64_MAX - size)
+    {
+        return INT64_MAX;
+    }
+    return low + size;
 }
 
 static int64_t highest_equivalent_value(const struct hdr_histogram* h, int64_t value)
@@ -915,7 +925,14 @@ static bool move_next(struct hdr_iter* iter)
         iter->h, bucket_index, sub_bucket_index);
     iter->lowest_equivalent_value = leq;
     iter->value = value;
-    iter->highest_equivalent_value = leq + size_of_equivalent_value_range - 1;
+    /* Saturate: for the top bucket leq + size overflows int64 (UB). The
+       all-values iterator visits every bucket, so this fires on any full
+       iteration (hdr_stddev, hdr_percentiles_print, ...) of a histogram whose
+       highest_trackable_value is near INT64_MAX. */
+    iter->highest_equivalent_value =
+        (leq > INT64_MAX - size_of_equivalent_value_range)
+            ? INT64_MAX
+            : leq + size_of_equivalent_value_range - 1;
     iter->median_equivalent_value = leq + (size_of_equivalent_value_range >> 1);
 
     return true;

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -293,10 +293,7 @@ int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t val
 {
     int64_t low  = lowest_equivalent_value(h, value);
     int64_t size = hdr_size_of_equivalent_value_range(h, value);
-    /* For a value in the top bucket, low + size can exceed INT64_MAX, which is
-       signed-overflow UB. Saturate instead; highest_equivalent_value() then
-       returns INT64_MAX - 1 for the top bucket rather than overflowing. This
-       feeds hdr_max / hdr_value_at_percentile / hdr_percentiles_print. */
+    /* saturate: top-bucket low+size overflows int64 (UB) */
     if (low > INT64_MAX - size)
     {
         return INT64_MAX;
@@ -306,7 +303,14 @@ int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t val
 
 static int64_t highest_equivalent_value(const struct hdr_histogram* h, int64_t value)
 {
-    return hdr_next_non_equivalent_value(h, value) - 1;
+    int64_t low  = lowest_equivalent_value(h, value);
+    int64_t size = hdr_size_of_equivalent_value_range(h, value);
+    /* clamp: top-bucket low+size-1 overflows int64; keep value <= highest_equivalent_value */
+    if (low > INT64_MAX - size)
+    {
+        return INT64_MAX;
+    }
+    return low + size - 1;
 }
 
 int64_t hdr_median_equivalent_value(const struct hdr_histogram *h, int64_t value)
@@ -925,10 +929,7 @@ static bool move_next(struct hdr_iter* iter)
         iter->h, bucket_index, sub_bucket_index);
     iter->lowest_equivalent_value = leq;
     iter->value = value;
-    /* Saturate: for the top bucket leq + size overflows int64 (UB). The
-       all-values iterator visits every bucket, so this fires on any full
-       iteration (hdr_stddev, hdr_percentiles_print, ...) of a histogram whose
-       highest_trackable_value is near INT64_MAX. */
+    /* saturate: top-bucket leq+size overflows int64 (UB) */
     iter->highest_equivalent_value =
         (leq > INT64_MAX - size_of_equivalent_value_range)
             ? INT64_MAX

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -1297,12 +1297,15 @@ void hdr_iter_log_init(
     iter->specifics.log.count_added_in_this_iteration_step = 0;
     iter->specifics.log.log_base = log_base;
     iter->specifics.log.next_value_reporting_level = value_units_first_bucket;
-    if (value_units_first_bucket <= 0 || log_base <= 1.0)
+    if (value_units_first_bucket <= 0 || !isfinite(log_base) || log_base <= 1.0 ||
+        log_base >= (double) INT64_MAX)
     {
         /* non-positive first bucket or base <= 1 never advances; a negative
            first bucket also reaches negative left-shift UB in
-           lowest_equivalent_value below. Pin to the terminating state (matches
-           the advance-path guard). */
+           lowest_equivalent_value below. A non-finite (NaN/Inf) or out-of-int64-
+           range base would hit float-cast-overflow UB at the (int64_t) log_base
+           cast in log_iter_next. Pin to the terminating state (matches the
+           advance-path guard) so that cast is never reached for a bad base. */
         iter->specifics.log.next_value_reporting_level = INT64_MAX;
         iter->specifics.log.next_value_reporting_level_lowest_equivalent = INT64_MAX;
     }

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -1213,8 +1213,19 @@ void hdr_iter_linear_init(struct hdr_iter* iter, const struct hdr_histogram* h, 
 
     iter->specifics.linear.count_added_in_this_iteration_step = 0;
     iter->specifics.linear.value_units_per_bucket = value_units_per_bucket;
-    iter->specifics.linear.next_value_reporting_level = value_units_per_bucket;
-    iter->specifics.linear.next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(h, value_units_per_bucket);
+    if (value_units_per_bucket <= 0)
+    {
+        /* non-positive step never advances; a negative one also reaches
+           negative left-shift UB in lowest_equivalent_value below. Pin to the
+           terminating state (matches the advance-path guard). */
+        iter->specifics.linear.next_value_reporting_level = INT64_MAX;
+        iter->specifics.linear.next_value_reporting_level_lowest_equivalent = INT64_MAX;
+    }
+    else
+    {
+        iter->specifics.linear.next_value_reporting_level = value_units_per_bucket;
+        iter->specifics.linear.next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(h, value_units_per_bucket);
+    }
 
     iter->_next_fp = iter_linear_next;
 }
@@ -1286,7 +1297,19 @@ void hdr_iter_log_init(
     iter->specifics.log.count_added_in_this_iteration_step = 0;
     iter->specifics.log.log_base = log_base;
     iter->specifics.log.next_value_reporting_level = value_units_first_bucket;
-    iter->specifics.log.next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(h, value_units_first_bucket);
+    if (value_units_first_bucket <= 0 || log_base <= 1.0)
+    {
+        /* non-positive first bucket or base <= 1 never advances; a negative
+           first bucket also reaches negative left-shift UB in
+           lowest_equivalent_value below. Pin to the terminating state (matches
+           the advance-path guard). */
+        iter->specifics.log.next_value_reporting_level = INT64_MAX;
+        iter->specifics.log.next_value_reporting_level_lowest_equivalent = INT64_MAX;
+    }
+    else
+    {
+        iter->specifics.log.next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(h, value_units_first_bucket);
+    }
 
     iter->_next_fp = log_iter_next;
 }

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -1160,9 +1160,24 @@ static bool iter_linear_next(struct hdr_iter* iter)
             {
                 update_iterated_values(iter, linear->next_value_reporting_level);
 
-                linear->next_value_reporting_level += linear->value_units_per_bucket;
-                linear->next_value_reporting_level_lowest_equivalent =
-                    lowest_equivalent_value(iter->h, linear->next_value_reporting_level);
+                /* Advance to the next reporting level, guarding the int64
+                   overflow of `+= value_units_per_bucket` for a near-INT64_MAX
+                   range. Once no further level is representable, pin the level
+                   AND its lowest-equivalent to INT64_MAX: no bucket value ever
+                   reaches INT64_MAX, so the `iter->value >= ...` test above can
+                   no longer fire and the iterator drains the remaining buckets
+                   and terminates instead of re-reporting the same level. */
+                if (linear->next_value_reporting_level > INT64_MAX - linear->value_units_per_bucket)
+                {
+                    linear->next_value_reporting_level = INT64_MAX;
+                    linear->next_value_reporting_level_lowest_equivalent = INT64_MAX;
+                }
+                else
+                {
+                    linear->next_value_reporting_level += linear->value_units_per_bucket;
+                    linear->next_value_reporting_level_lowest_equivalent =
+                        lowest_equivalent_value(iter->h, linear->next_value_reporting_level);
+                }
 
                 return true;
             }
@@ -1217,8 +1232,25 @@ static bool log_iter_next(struct hdr_iter *iter)
             {
                 update_iterated_values(iter, logarithmic->next_value_reporting_level);
 
-                logarithmic->next_value_reporting_level *= (int64_t)logarithmic->log_base;
-                logarithmic->next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(iter->h, logarithmic->next_value_reporting_level);
+                /* Advance to the next reporting level, guarding the int64
+                   overflow of `*= log_base` for a near-INT64_MAX range. As in
+                   the linear iterator, once no further level is representable
+                   pin the level and its lowest-equivalent to INT64_MAX so the
+                   emit test cannot re-fire and the iterator terminates. */
+                {
+                    int64_t base = (int64_t) logarithmic->log_base;
+                    if (base > 1 && logarithmic->next_value_reporting_level > INT64_MAX / base)
+                    {
+                        logarithmic->next_value_reporting_level = INT64_MAX;
+                        logarithmic->next_value_reporting_level_lowest_equivalent = INT64_MAX;
+                    }
+                    else
+                    {
+                        logarithmic->next_value_reporting_level *= base;
+                        logarithmic->next_value_reporting_level_lowest_equivalent =
+                            lowest_equivalent_value(iter->h, logarithmic->next_value_reporting_level);
+                    }
+                }
 
                 return true;
             }

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -947,7 +947,8 @@ static int64_t peek_next_value_from_index(struct hdr_iter* iter)
 static bool next_value_greater_than_reporting_level_upper_bound(
     struct hdr_iter *iter, int64_t reporting_level_upper_bound)
 {
-    if (iter->counts_index >= iter->h->counts_len)
+    /* peek reads counts_index+1; one past the last bucket is signed-shift UB */
+    if (iter->counts_index + 1 >= iter->h->counts_len)
     {
         return false;
     }
@@ -1160,15 +1161,11 @@ static bool iter_linear_next(struct hdr_iter* iter)
             {
                 update_iterated_values(iter, linear->next_value_reporting_level);
 
-                /* Advance to the next reporting level, guarding the int64
-                   overflow of `+= value_units_per_bucket` for a near-INT64_MAX
-                   range. Once no further level is representable, pin the level
-                   AND its lowest-equivalent to INT64_MAX: no bucket value ever
-                   reaches INT64_MAX, so the `iter->value >= ...` test above can
-                   no longer fire and the iterator drains the remaining buckets
-                   and terminates instead of re-reporting the same level. */
-                if (linear->next_value_reporting_level > INT64_MAX - linear->value_units_per_bucket)
+                /* advance the reporting level; on overflow pin to INT64_MAX so the emit test cannot re-fire and the iterator terminates */
+                if (linear->value_units_per_bucket <= 0 ||
+                    linear->next_value_reporting_level > INT64_MAX - linear->value_units_per_bucket)
                 {
+                    /* step <= 0 first: never-advances (infinite loop) and guards the subtraction; second clause is the overflow guard */
                     linear->next_value_reporting_level = INT64_MAX;
                     linear->next_value_reporting_level_lowest_equivalent = INT64_MAX;
                 }
@@ -1232,15 +1229,12 @@ static bool log_iter_next(struct hdr_iter *iter)
             {
                 update_iterated_values(iter, logarithmic->next_value_reporting_level);
 
-                /* Advance to the next reporting level, guarding the int64
-                   overflow of `*= log_base` for a near-INT64_MAX range. As in
-                   the linear iterator, once no further level is representable
-                   pin the level and its lowest-equivalent to INT64_MAX so the
-                   emit test cannot re-fire and the iterator terminates. */
+                /* advance the reporting level; on *= log_base overflow pin to INT64_MAX so the emit test cannot re-fire and it terminates */
                 {
                     int64_t base = (int64_t) logarithmic->log_base;
-                    if (base > 1 && logarithmic->next_value_reporting_level > INT64_MAX / base)
+                    if (base <= 1 || logarithmic->next_value_reporting_level > INT64_MAX / base)
                     {
+                        /* base <= 1 first: never-advances (infinite loop) and short-circuits /base so base==0 can't divide-by-zero; second clause is the overflow guard */
                         logarithmic->next_value_reporting_level = INT64_MAX;
                         logarithmic->next_value_reporting_level_lowest_equivalent = INT64_MAX;
                     }

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -941,14 +941,28 @@ static bool move_next(struct hdr_iter* iter)
 
 static int64_t peek_next_value_from_index(struct hdr_iter* iter)
 {
-    return hdr_value_at_index(iter->h, iter->counts_index + 1);
+    const int32_t index = iter->counts_index + 1;
+    int32_t bucket_index = (index >> iter->h->sub_bucket_half_count_magnitude) - 1;
+    int32_t sub_bucket_index = (index & (iter->h->sub_bucket_half_count - 1)) + iter->h->sub_bucket_half_count;
+    int32_t shift;
+    if (bucket_index < 0)
+    {
+        sub_bucket_index -= iter->h->sub_bucket_half_count;
+        bucket_index = 0;
+    }
+    shift = bucket_index + iter->h->unit_magnitude;
+    /* one past the top bucket shifts into the sign bit for a near-INT64_MAX range; saturate */
+    if (shift >= 63 || (int64_t) sub_bucket_index > (INT64_MAX >> shift))
+    {
+        return INT64_MAX;
+    }
+    return value_from_index(bucket_index, sub_bucket_index, iter->h->unit_magnitude);
 }
 
 static bool next_value_greater_than_reporting_level_upper_bound(
     struct hdr_iter *iter, int64_t reporting_level_upper_bound)
 {
-    /* peek reads counts_index+1; one past the last bucket is signed-shift UB */
-    if (iter->counts_index + 1 >= iter->h->counts_len)
+    if (iter->counts_index >= iter->h->counts_len)
     {
         return false;
     }
@@ -1232,9 +1246,9 @@ static bool log_iter_next(struct hdr_iter *iter)
                 /* advance the reporting level; on *= log_base overflow pin to INT64_MAX so the emit test cannot re-fire and it terminates */
                 {
                     int64_t base = (int64_t) logarithmic->log_base;
-                    if (base <= 1 || logarithmic->next_value_reporting_level > INT64_MAX / base)
+                    if (base <= 1 || logarithmic->next_value_reporting_level <= 0 || logarithmic->next_value_reporting_level > INT64_MAX / base)
                     {
-                        /* base <= 1 first: never-advances (infinite loop) and short-circuits /base so base==0 can't divide-by-zero; second clause is the overflow guard */
+                        /* base <= 1 first: never-advances (infinite loop) and short-circuits /base so base==0 can't divide-by-zero; level <= 0 never advances (0*=base loops) and *=base on a negative is overflow UB; last clause is the positive-overflow guard */
                         logarithmic->next_value_reporting_level = INT64_MAX;
                         logarithmic->next_value_reporting_level_lowest_equivalent = INT64_MAX;
                     }

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -8,6 +8,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <math.h>
 
 #include <stdio.h>
 #include <hdr/hdr_histogram.h>
@@ -575,18 +576,22 @@ static char* test_top_bucket_value_range_no_overflow(void)
     hdr_record_value(h, INT64_MAX);
     hdr_record_value(h, 5);
 
-    /* The top bucket saturates to INT64_MAX; a recorded INT64_MAX must not
-       report a max below itself (invariant value <= highest_equivalent_value). */
-    mu_assert("max saturates to INT64_MAX", INT64_MAX == hdr_max(h));
-    mu_assert("p100 saturates to INT64_MAX", INT64_MAX == hdr_value_at_percentile(h, 100.0));
-    /* Plain-build guard: on the buggy code low + size overflows and
-       hdr_next_non_equivalent_value(INT64_MAX) wraps to INT64_MIN. */
+    /* hdr_next_non_equivalent_value is the only assertion here that distinguishes
+       fixed from broken on a plain (non-UBSan) build: on the buggy code low + size
+       overflows and hdr_next_non_equivalent_value(INT64_MAX) wraps to INT64_MIN,
+       whereas the fix saturates to INT64_MAX. */
     mu_assert("next_non_equivalent_value saturates, not wrapped negative",
               INT64_MAX == hdr_next_non_equivalent_value(h, INT64_MAX));
-    mu_assert("stddev is finite", hdr_stddev(h) == hdr_stddev(h));
+    /* The remaining checks pass on the unfixed code too (the overflow is UB but
+       happens to produce these values on common targets); they are UBSan-only
+       guards against the signed-overflow itself, plus invariant/sanity pins. */
+    mu_assert("max saturates to INT64_MAX", INT64_MAX == hdr_max(h));
+    mu_assert("p100 saturates to INT64_MAX", INT64_MAX == hdr_value_at_percentile(h, 100.0));
+    mu_assert("stddev is finite", isfinite(hdr_stddev(h)));
 
     /* The all-values iterator visits the top bucket; its highest_equivalent_value
-       must stay a representable non-negative int64 (was an overflowed value). */
+       must stay a representable non-negative int64 (UBSan-only guard: the overflow
+       is UB, but the wrapped value is typically still >= 0 on a plain build). */
     hdr_iter_init(&iter, h);
     while (hdr_iter_next(&iter))
     {

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -674,6 +674,21 @@ static char* test_iterator_reporting_level_no_overflow(void)
     {
         mu_assert("log iterator (level<=0) must terminate", ++steps < 1000000);
     }
+    /* Negative init params reach negative left-shift UB in lowest_equivalent_value
+       at init time (before any advance-path guard). Must not trip UBSan and must
+       terminate. */
+    hdr_iter_linear_init(&iter, h, -1);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("linear iterator (vpb=-1) must terminate", ++steps < 1000000);
+    }
+    hdr_iter_log_init(&iter, h, -100, 2.0);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator (first bucket=-100) must terminate", ++steps < 1000000);
+    }
     hdr_close(h);
 
     /* Value-pinning regression: an over-eager peek guard truncated the tail of

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 
 #include <stdio.h>
+#include <math.h>
 #include <hdr/hdr_histogram.h>
 #include <hdr/hdr_interval_recorder.h>
 
@@ -688,6 +689,27 @@ static char* test_iterator_reporting_level_no_overflow(void)
     while (hdr_iter_next(&iter))
     {
         mu_assert("log iterator (first bucket=-100) must terminate", ++steps < 1000000);
+    }
+    /* Non-finite / out-of-int64-range log_base must not trip float-cast-overflow
+       UBSan at the (int64_t) log_base cast in log_iter_next, and must terminate.
+       The init guard pins the terminating state so the cast is never reached. */
+    hdr_iter_log_init(&iter, h, 1, 1e300);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator (base=1e300) must terminate", ++steps < 1000000);
+    }
+    hdr_iter_log_init(&iter, h, 1, INFINITY);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator (base=INF) must terminate", ++steps < 1000000);
+    }
+    hdr_iter_log_init(&iter, h, 1, NAN);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator (base=NaN) must terminate", ++steps < 1000000);
     }
     hdr_close(h);
 

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -667,6 +667,31 @@ static char* test_iterator_reporting_level_no_overflow(void)
     {
         mu_assert("log iterator (base<=1) must terminate", ++steps < 1000000);
     }
+    /* Non-positive log level must terminate (0 *= base loops forever otherwise). */
+    hdr_iter_log_init(&iter, h, 0, 2.0);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator (level<=0) must terminate", ++steps < 1000000);
+    }
+    hdr_close(h);
+
+    /* Value-pinning regression: an over-eager peek guard truncated the tail of
+       ordinary linear iteration. init(1,1000,1) + record 999, linear step 1
+       must emit one step per equivalent-value range up to the top of the last
+       bucket (value_iterated_to == 1023). A tail-truncation regresses loudly. */
+    h = NULL;
+    mu_assert("Should allocate", 0 == hdr_init(1, 1000, 1, &h));
+    hdr_record_value(h, 999);
+    hdr_iter_linear_init(&iter, h, 1);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        steps++;
+    }
+    mu_assert("linear step=1 must emit 1023 steps", 1023 == steps);
+    mu_assert("linear step=1 must reach top of last bucket (1023)",
+              1023 == iter.value_iterated_to);
     hdr_close(h);
     return 0;
 }

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -598,6 +598,40 @@ static char* test_top_bucket_value_range_no_overflow(void)
     return 0;
 }
 
+static char* test_iterator_reporting_level_no_overflow(void)
+{
+    /* Regression (UBSan, found via fuzzing): the linear and logarithmic
+       iterators advanced their reporting level with `+= value_units_per_bucket`
+       / `*= log_base`, which overflowed int64 for a near-INT64_MAX range. The
+       level now saturates at INT64_MAX and the iterators still terminate. */
+    struct hdr_histogram* h = NULL;
+    struct hdr_iter iter;
+    long steps;
+
+    mu_assert("Should allocate", 0 == hdr_init(1, INT64_MAX, 3, &h));
+    hdr_record_value(h, INT64_MAX);
+    hdr_record_value(h, 5);
+
+    /* A huge linear bucket makes the reporting level cross INT64_MAX quickly. */
+    hdr_iter_linear_init(&iter, h, INT64_C(1) << 62);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("linear iterator must terminate", ++steps < 1000000);
+    }
+
+    /* Base-2 log iteration reaches INT64_MAX in ~64 steps. */
+    hdr_iter_log_init(&iter, h, 1, 2.0);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator must terminate", ++steps < 1000000);
+    }
+
+    hdr_close(h);
+    return 0;
+}
+
 static struct mu_result all_tests(void)
 {
     mu_run_test(test_create);
@@ -608,6 +642,7 @@ static struct mu_result all_tests(void)
     mu_run_test(test_get_min_value);
     mu_run_test(test_get_max_value);
     mu_run_test(test_top_bucket_value_range_no_overflow);
+    mu_run_test(test_iterator_reporting_level_no_overflow);
     mu_run_test(test_percentiles);
     mu_run_test(test_percentiles_by_value_at_percentiles);
     mu_run_test(test_recorded_values);

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -561,6 +561,37 @@ static char* reset_histogram_on_sample_and_recycle(void)
     return 0;
 }
 
+static char* test_top_bucket_value_range_no_overflow(void)
+{
+    /* Regression (UBSan, found via fuzzing): for a histogram whose
+       highest_trackable_value is near INT64_MAX, the top bucket's
+       lowest_equivalent + size_of_equivalent_value_range overflowed int64,
+       corrupting hdr_max / hdr_value_at_percentile / hdr_stddev and the
+       all-values iterator. Those value-range computations now saturate. */
+    struct hdr_histogram* h = NULL;
+    struct hdr_iter iter;
+
+    mu_assert("Should allocate", 0 == hdr_init(1, INT64_MAX, 3, &h));
+    hdr_record_value(h, INT64_MAX);
+    hdr_record_value(h, 5);
+
+    mu_assert("max is representable and non-negative", hdr_max(h) > 0);
+    mu_assert("p100 is representable and non-negative", hdr_value_at_percentile(h, 100.0) > 0);
+    mu_assert("stddev is finite", hdr_stddev(h) == hdr_stddev(h));
+
+    /* A full iteration visits the top bucket; highest_equivalent_value must
+       stay a representable non-negative int64 (was a negative/overflowed value). */
+    hdr_iter_init(&iter, h);
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("iter highest_equivalent_value stays representable",
+                  iter.highest_equivalent_value >= 0);
+    }
+
+    hdr_close(h);
+    return 0;
+}
+
 static struct mu_result all_tests(void)
 {
     mu_run_test(test_create);
@@ -570,6 +601,7 @@ static struct mu_result all_tests(void)
     mu_run_test(test_total_count);
     mu_run_test(test_get_min_value);
     mu_run_test(test_get_max_value);
+    mu_run_test(test_top_bucket_value_range_no_overflow);
     mu_run_test(test_percentiles);
     mu_run_test(test_percentiles_by_value_at_percentiles);
     mu_run_test(test_recorded_values);

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -629,6 +629,45 @@ static char* test_iterator_reporting_level_no_overflow(void)
     }
 
     hdr_close(h);
+
+    /* Peek-past-end variant: at the last bucket the iterator peeked
+       hdr_value_at_index(h, counts_len), a signed-shift overflow for a
+       near-INT64_MAX range. A single top-bucket value with sig=1 exercises it. */
+    h = NULL;
+    mu_assert("Should allocate", 0 == hdr_init(1, INT64_C(1) << 62, 1, &h));
+    hdr_record_value(h, INT64_C(1) << 62);
+    hdr_iter_linear_init(&iter, h, INT64_MAX - 1);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("linear iterator (peek) must terminate", ++steps < 1000000);
+    }
+    hdr_iter_log_init(&iter, h, 1000, 2.0);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator (peek) must terminate", ++steps < 1000000);
+    }
+    hdr_close(h);
+
+    /* Degenerate iterator parameters must terminate rather than loop forever:
+       value_units_per_bucket == 0 and log_base <= 1. */
+    h = NULL;
+    mu_assert("Should allocate", 0 == hdr_init(1, 1000000, 3, &h));
+    hdr_record_value(h, 1234);
+    hdr_iter_linear_init(&iter, h, 0);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("linear iterator (vpb=0) must terminate", ++steps < 1000000);
+    }
+    hdr_iter_log_init(&iter, h, 1000, 1.0);
+    steps = 0;
+    while (hdr_iter_next(&iter))
+    {
+        mu_assert("log iterator (base<=1) must terminate", ++steps < 1000000);
+    }
+    hdr_close(h);
     return 0;
 }
 

--- a/test/hdr_histogram_test.c
+++ b/test/hdr_histogram_test.c
@@ -575,12 +575,18 @@ static char* test_top_bucket_value_range_no_overflow(void)
     hdr_record_value(h, INT64_MAX);
     hdr_record_value(h, 5);
 
-    mu_assert("max is representable and non-negative", hdr_max(h) > 0);
-    mu_assert("p100 is representable and non-negative", hdr_value_at_percentile(h, 100.0) > 0);
+    /* The top bucket saturates to INT64_MAX; a recorded INT64_MAX must not
+       report a max below itself (invariant value <= highest_equivalent_value). */
+    mu_assert("max saturates to INT64_MAX", INT64_MAX == hdr_max(h));
+    mu_assert("p100 saturates to INT64_MAX", INT64_MAX == hdr_value_at_percentile(h, 100.0));
+    /* Plain-build guard: on the buggy code low + size overflows and
+       hdr_next_non_equivalent_value(INT64_MAX) wraps to INT64_MIN. */
+    mu_assert("next_non_equivalent_value saturates, not wrapped negative",
+              INT64_MAX == hdr_next_non_equivalent_value(h, INT64_MAX));
     mu_assert("stddev is finite", hdr_stddev(h) == hdr_stddev(h));
 
-    /* A full iteration visits the top bucket; highest_equivalent_value must
-       stay a representable non-negative int64 (was a negative/overflowed value). */
+    /* The all-values iterator visits the top bucket; its highest_equivalent_value
+       must stay a representable non-negative int64 (was an overflowed value). */
     hdr_iter_init(&iter, h);
     while (hdr_iter_next(&iter))
     {


### PR DESCRIPTION
Stacked on #148 (the iterators call `move_next`, whose value-range overflow #148 fixes). **Base this PR on #148; retarget to `main` once #148 merges.**

## Bug (found by adversarial review during the ClusterFuzzLite effort)
For a histogram with `highest_trackable_value` near `INT64_MAX`, the linear and log iterators overflow int64 when advancing the reporting level:
- `iter_linear_next` (`:1162`): `next_value_reporting_level += value_units_per_bucket`
- `log_iter_next` (`:1219`): `next_value_reporting_level *= (int64_t) log_base`

Both are in-contract (public iterators) and reachable via any full linear/log iteration of such a histogram; the wrapped negative level then triggers a negative left-shift in `lowest_equivalent_value`.

## Fix
Saturate the reporting level at `INT64_MAX` when the next step would overflow. **Termination:** naive saturation would re-report the top level forever (the emit branch doesn't advance `counts_index`). Since no bucket value ever equals `INT64_MAX`, pinning `next_value_reporting_level_lowest_equivalent` to `INT64_MAX` as well makes the `iter->value >= level` test stop firing, so the iterator drains remaining buckets and terminates.

## Verification (ASan+UBSan)
- Linear (`units=2^62`) and log (`base 2`) over an `INT64_MAX` histogram: **no trap, terminate** (2 and 64 steps). Normal-range iteration unchanged. Regression test added; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)